### PR TITLE
fix(recursive): per-instance config with working defaults

### DIFF
--- a/internal/upstream/resolvers/recursive/per_instance_test.go
+++ b/internal/upstream/resolvers/recursive/per_instance_test.go
@@ -1,0 +1,85 @@
+package recursive
+
+import (
+	"testing"
+
+	"github.com/zhouchenh/secDNS/pkg/upstream/resolver"
+)
+
+// describeRecursive builds a recursive resolver from a JSON-like config map via the registered
+// descriptor, mirroring how the config loader instantiates named resolvers.
+func describeRecursive(t *testing.T, cfg map[string]interface{}) *Recursive {
+	t.Helper()
+	describable, ok := resolver.GetResolverDescriptorByTypeName("recursive")
+	if !ok {
+		t.Fatalf("descriptor for recursive not registered")
+	}
+	obj, s, f := describable.Describe(cfg)
+	if s < 1 || f > 0 {
+		t.Fatalf("describe failed for cfg %v: success=%d failure=%d", cfg, s, f)
+	}
+	r, ok := obj.(*Recursive)
+	if !ok || r == nil {
+		t.Fatalf("describe returned %T (nil=%v), want non-nil *Recursive", obj, r == nil)
+	}
+	return r
+}
+
+// TestRecursiveDescriptorEmptyConfigUsesDefaults verifies that a recursive resolver can be
+// constructed from an empty config, i.e. every key is optional and falls back to its default.
+// Regression: validateDNSSEC/qnameMinimize/ednsSize previously had no DefaultValue fallback, so
+// omitting any of them made the descriptor fail and the resolver be silently dropped (the
+// documented minimal example did not load).
+func TestRecursiveDescriptorEmptyConfigUsesDefaults(t *testing.T) {
+	r := describeRecursive(t, map[string]interface{}{})
+	if r.ValidateDNSSEC != "permissive" {
+		t.Errorf("validateDNSSEC default = %q, want %q", r.ValidateDNSSEC, "permissive")
+	}
+	if !r.QNameMinimize {
+		t.Errorf("qnameMinimize default = false, want true")
+	}
+	if r.EDNSSize != 1232 {
+		t.Errorf("ednsSize default = %d, want 1232", r.EDNSSize)
+	}
+	if len(r.RootServers) == 0 {
+		t.Errorf("rootServers default is empty, want built-in root hints")
+	}
+}
+
+// TestRecursiveDescriptorPartialConfigUsesDefaults verifies that supplying only one key still
+// constructs the resolver and defaults the rest.
+func TestRecursiveDescriptorPartialConfigUsesDefaults(t *testing.T) {
+	r := describeRecursive(t, map[string]interface{}{"validateDNSSEC": "strict"})
+	if r.ValidateDNSSEC != "strict" {
+		t.Errorf("validateDNSSEC = %q, want strict", r.ValidateDNSSEC)
+	}
+	if !r.QNameMinimize {
+		t.Errorf("qnameMinimize default = false, want true")
+	}
+	if r.EDNSSize != 1232 {
+		t.Errorf("ednsSize default = %d, want 1232", r.EDNSSize)
+	}
+}
+
+// TestRecursiveDescriptorInstancesAreIndependent verifies that two recursive resolvers built
+// from different configs do not share state. Regression: the descriptor previously seeded every
+// instance from one shared *Recursive default pointer, so the last-parsed config overwrote the
+// others (e.g. a strict resolver silently downgraded to permissive when a permissive resolver
+// was also configured).
+func TestRecursiveDescriptorInstancesAreIndependent(t *testing.T) {
+	strict := describeRecursive(t, map[string]interface{}{"validateDNSSEC": "strict"})
+	permissive := describeRecursive(t, map[string]interface{}{"validateDNSSEC": "permissive"})
+	if strict == permissive {
+		t.Fatalf("two recursive resolvers share the same *Recursive instance")
+	}
+	if strict.ValidateDNSSEC != "strict" {
+		t.Errorf("first resolver validateDNSSEC = %q, want strict", strict.ValidateDNSSEC)
+	}
+	if permissive.ValidateDNSSEC != "permissive" {
+		t.Errorf("second resolver validateDNSSEC = %q, want permissive", permissive.ValidateDNSSEC)
+	}
+	strict.ValidateDNSSEC = "off"
+	if permissive.ValidateDNSSEC != "permissive" {
+		t.Errorf("mutating the first resolver changed the second: got %q", permissive.ValidateDNSSEC)
+	}
+}

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -122,9 +122,6 @@ func init() {
 		Type: typeOfRecursive,
 		Filler: descriptor.Fillers{
 			descriptor.ObjectFiller{
-				ValueSource: descriptor.DefaultValue{Value: defaultRecursiveConfig},
-			},
-			descriptor.ObjectFiller{
 				ObjectPath: descriptor.Path{"RootServers"},
 				ValueSource: descriptor.ValueSources{
 					descriptor.ObjectAtPath{
@@ -166,74 +163,83 @@ func init() {
 			},
 			descriptor.ObjectFiller{
 				ObjectPath: descriptor.Path{"ValidateDNSSEC"},
-				ValueSource: descriptor.ObjectAtPath{
-					ObjectPath: descriptor.Path{"validateDNSSEC"},
-					AssignableKind: descriptor.ConvertibleKind{
-						Kind: descriptor.KindString,
-						ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
-							str, ok := original.(string)
-							if !ok {
-								return nil, false
-							}
-							str = strings.ToLower(strings.TrimSpace(str))
-							switch str {
-							case "strict", "permissive", "off":
-								return str, true
-							default:
-								return nil, false
-							}
-						},
-					},
-				},
-			},
-			descriptor.ObjectFiller{
-				ObjectPath: descriptor.Path{"QNameMinimize"},
-				ValueSource: descriptor.ObjectAtPath{
-					ObjectPath: descriptor.Path{"qnameMinimize"},
-					AssignableKind: descriptor.AssignableKinds{
-						descriptor.KindBool,
-						descriptor.ConvertibleKind{
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath: descriptor.Path{"validateDNSSEC"},
+						AssignableKind: descriptor.ConvertibleKind{
 							Kind: descriptor.KindString,
 							ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
-								switch strings.ToLower(strings.TrimSpace(original.(string))) {
-								case "true":
-									return true, true
-								case "false":
-									return false, true
+								str, ok := original.(string)
+								if !ok {
+									return nil, false
+								}
+								str = strings.ToLower(strings.TrimSpace(str))
+								switch str {
+								case "strict", "permissive", "off":
+									return str, true
 								default:
 									return nil, false
 								}
 							},
 						},
 					},
+					descriptor.DefaultValue{Value: "permissive"},
+				},
+			},
+			descriptor.ObjectFiller{
+				ObjectPath: descriptor.Path{"QNameMinimize"},
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath: descriptor.Path{"qnameMinimize"},
+						AssignableKind: descriptor.AssignableKinds{
+							descriptor.KindBool,
+							descriptor.ConvertibleKind{
+								Kind: descriptor.KindString,
+								ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+									switch strings.ToLower(strings.TrimSpace(original.(string))) {
+									case "true":
+										return true, true
+									case "false":
+										return false, true
+									default:
+										return nil, false
+									}
+								},
+							},
+						},
+					},
+					descriptor.DefaultValue{Value: true},
 				},
 			},
 			descriptor.ObjectFiller{
 				ObjectPath: descriptor.Path{"EDNSSize"},
-				ValueSource: descriptor.ObjectAtPath{
-					ObjectPath: descriptor.Path{"ednsSize"},
-					AssignableKind: descriptor.AssignableKinds{
-						descriptor.ConvertibleKind{
-							Kind: descriptor.KindFloat64,
-							ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
-								val := int(original.(float64))
-								if val <= 0 || val > 4096 {
-									return nil, false
-								}
-								return uint16(val), true
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath: descriptor.Path{"ednsSize"},
+						AssignableKind: descriptor.AssignableKinds{
+							descriptor.ConvertibleKind{
+								Kind: descriptor.KindFloat64,
+								ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+									val := int(original.(float64))
+									if val <= 0 || val > 4096 {
+										return nil, false
+									}
+									return uint16(val), true
+								},
 							},
-						},
-						descriptor.ConvertibleKind{
-							Kind: descriptor.KindString,
-							ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
-								i, err := strconv.Atoi(strings.TrimSpace(original.(string)))
-								if err != nil || i <= 0 || i > 4096 {
-									return nil, false
-								}
-								return uint16(i), true
+							descriptor.ConvertibleKind{
+								Kind: descriptor.KindString,
+								ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+									i, err := strconv.Atoi(strings.TrimSpace(original.(string)))
+									if err != nil || i <= 0 || i > 4096 {
+										return nil, false
+									}
+									return uint16(i), true
+								},
 							},
 						},
 					},
+					descriptor.DefaultValue{Value: uint16(1232)},
 				},
 			},
 			durationFiller("Timeout", "timeout", defaultRecursiveConfig.Timeout),


### PR DESCRIPTION
## Problem

Two defects in the `recursive` resolver descriptor:

1. **Resolver silently dropped when keys are omitted.** The `validateDNSSEC`, `qnameMinimize` and `ednsSize` fillers had no `DefaultValue` fallback (every other filler does). Omitting any one of them made the descriptor's success/failure gate (`s>0 && f<1`) reject the resolver, so it never registered and any reference (`defaultResolver`, rules) failed with `Resolver named X not found`. The documented minimal example (`docs/resolvers/recursive.md`) did not load.

2. **All recursive resolvers shared one mutable struct.** The root filler seeded every instance from the single shared `*Recursive` pointer `defaultRecursiveConfig`. Because the registered type is a pointer type, every built resolver *was* that shared struct — sharing `ValidateDNSSEC` plus runtime state (`scoreboard`, `validator`, `reqGroup`, `glueCache`, `initOnce`). With more than one recursive resolver, the last-parsed config (Go map order is randomized) won for all of them; e.g. a `strict` resolver silently behaved as `permissive`.

## Fix

- Drop the shared root-default filler. `go-descriptor` then allocates a fresh `*Recursive` per `Describe`, giving each resolver its own config and runtime state.
- Give the three fillers explicit `DefaultValue` fallbacks (`permissive` / `true` / `1232`), matching the documented defaults.

`defaultRecursiveConfig` is retained as the source of the numeric defaults used by the `durationFiller`/`intFiller` helpers; it is no longer used as the object base.

## Tests

Added `per_instance_test.go`:
- empty config builds with documented defaults;
- partial config defaults the rest;
- two resolvers built from different configs are independent (distinct instances, no cross-mutation).

`go build/vet/test ./...` green; `go test -race ./...` clean.