### PR TITLE
fix(nameserver): validate upstream responses and randomize query ID

### DIFF
--- a/internal/upstream/resolvers/nameserver/types.go
+++ b/internal/upstream/resolvers/nameserver/types.go
@@ -59,34 +59,37 @@ func (ns *NameServer) Resolve(query *dns.Msg, depth int) (*dns.Msg, error) {
 		ns.initClient()
 	})
 
-	// Apply ECS configuration to query if configured
+	// Work on a copy so the caller's message is never mutated, and randomize the
+	// transaction ID for the upstream query to raise the bar for off-path spoofing.
+	// The caller's original ID is restored on the reply before returning.
+	originalID := query.Id
+	outbound := query.Copy()
+	outbound.Id = dns.Id()
+
+	// Apply ECS configuration to the outbound query if configured.
 	if ns.ecsConfig != nil {
-		// Create a copy of the query to avoid modifying the original
-		queryCopy := query.Copy()
-		if err := ns.ecsConfig.ApplyToQuery(queryCopy); err != nil {
+		if err := ns.ecsConfig.ApplyToQuery(outbound); err != nil {
 			return nil, err
 		}
-		query = queryCopy
 	}
 
 	address := net.JoinHostPort(ns.Address.String(), strconv.Itoa(int(ns.Port)))
 
-	// Try with the configured protocol
-	msg, err := ns.queryWithProtocol(query, address, ns.Protocol)
+	// Try with the configured protocol.
+	msg, err := ns.queryWithProtocol(outbound, address, ns.Protocol)
 	if err != nil {
 		return nil, err
 	}
 
-	// If UDP response is truncated, retry with TCP
+	// If the UDP response is truncated, retry over TCP; keep the truncated UDP
+	// response if the TCP attempt fails.
 	if msg.Truncated && ns.Protocol == "udp" {
-		tcpMsg, tcpErr := ns.queryWithProtocol(query, address, "tcp")
-		if tcpErr != nil {
-			// Return original truncated response if TCP fails
-			return msg, nil
+		if tcpMsg, tcpErr := ns.queryWithProtocol(outbound, address, "tcp"); tcpErr == nil {
+			msg = tcpMsg
 		}
-		return tcpMsg, nil
 	}
 
+	msg.Id = originalID
 	return msg, nil
 }
 
@@ -117,11 +120,38 @@ func (ns *NameServer) queryWithProtocol(query *dns.Msg, address string, protocol
 	if err := connection.WriteMsg(query); err != nil {
 		return nil, err
 	}
-	msg, err := connection.ReadMsg()
-	if err != nil {
-		return nil, err
+	// Read until a response that matches the query (transaction ID + question)
+	// arrives or the deadline fires, discarding unsolicited or mismatched datagrams
+	// so a forged or stray packet cannot be accepted as the answer.
+	for {
+		msg, err := connection.ReadMsg()
+		if err != nil {
+			return nil, err
+		}
+		if responseMatchesQuery(msg, query) {
+			return msg, nil
+		}
 	}
-	return msg, nil
+}
+
+// responseMatchesQuery reports whether resp is a plausible answer to query: the
+// transaction ID and the question section (name/type/class) must match. Name
+// comparison is case-insensitive per RFC 4343.
+func responseMatchesQuery(resp, query *dns.Msg) bool {
+	if resp == nil || resp.Id != query.Id {
+		return false
+	}
+	if len(resp.Question) != len(query.Question) {
+		return false
+	}
+	for i := range query.Question {
+		q := query.Question[i]
+		r := resp.Question[i]
+		if r.Qtype != q.Qtype || r.Qclass != q.Qclass || !strings.EqualFold(r.Name, q.Name) {
+			return false
+		}
+	}
+	return true
 }
 
 func (ns *NameServer) NameServerResolver() {}

--- a/internal/upstream/resolvers/nameserver/types_test.go
+++ b/internal/upstream/resolvers/nameserver/types_test.go
@@ -77,12 +77,128 @@ func mockDNSClient(protocol string, resp *dns.Msg, dialCounter *int) *client {
 		go func() {
 			defer serverConn.Close()
 			serverDNS := &dns.Conn{Conn: serverConn}
-			if _, err := serverDNS.ReadMsg(); err != nil {
+			req, err := serverDNS.ReadMsg()
+			if err != nil {
 				return
 			}
 			if resp != nil {
-				_ = serverDNS.WriteMsg(resp.Copy())
+				// Echo the request's transaction ID, as a real DNS server does, so
+				// the response passes the resolver's ID/question validation.
+				out := resp.Copy()
+				out.Id = req.Id
+				_ = serverDNS.WriteMsg(out)
 			}
+		}()
+		return clientConn, nil
+	}
+	c.dialFunc = dial
+	c.dialTLSFunc = dial
+	return c
+}
+
+func TestResponseMatchesQuery(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	q.Id = 0x1234
+
+	good := new(dns.Msg)
+	good.SetReply(q)
+	if !responseMatchesQuery(good, q) {
+		t.Fatalf("matching response was rejected")
+	}
+
+	badID := good.Copy()
+	badID.Id = q.Id ^ 0xFFFF
+	if responseMatchesQuery(badID, q) {
+		t.Fatalf("response with mismatched transaction ID was accepted")
+	}
+
+	badName := new(dns.Msg)
+	badName.SetQuestion("evil.example.com.", dns.TypeA)
+	badName.Id = q.Id
+	if responseMatchesQuery(badName, q) {
+		t.Fatalf("response with mismatched question name was accepted")
+	}
+
+	badType := new(dns.Msg)
+	badType.SetQuestion("example.com.", dns.TypeAAAA)
+	badType.Id = q.Id
+	if responseMatchesQuery(badType, q) {
+		t.Fatalf("response with mismatched qtype was accepted")
+	}
+
+	mixedCase := new(dns.Msg)
+	mixedCase.SetQuestion("ExAmPlE.CoM.", dns.TypeA)
+	mixedCase.Id = q.Id
+	if !responseMatchesQuery(mixedCase, q) {
+		t.Fatalf("case-insensitive question name match was rejected")
+	}
+}
+
+// TestNameServerSkipsSpoofedThenAcceptsValid verifies that a datagram whose
+// transaction ID does not match the (randomized) query is discarded and the
+// resolver keeps reading until the genuine answer arrives.
+func TestNameServerSkipsSpoofedThenAcceptsValid(t *testing.T) {
+	query := new(dns.Msg)
+	query.SetQuestion("example.com.", dns.TypeA)
+
+	valid := new(dns.Msg)
+	valid.SetReply(query)
+	validA, err := dns.NewRR("example.com. 60 IN A 93.184.216.34")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	valid.Answer = []dns.RR{validA}
+
+	ns := &NameServer{
+		Protocol:     "udp",
+		Address:      net.IPv4(127, 0, 0, 1),
+		Port:         53,
+		QueryTimeout: time.Second,
+	}
+	ns.queryClient = mockSpoofThenValidClient(valid)
+	ns.initOnce.Do(func() {})
+
+	resp, err := ns.Resolve(query, 5)
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(resp.Answer))
+	}
+	if a, ok := resp.Answer[0].(*dns.A); !ok || a.A.String() != "93.184.216.34" {
+		t.Fatalf("expected the genuine answer 93.184.216.34, got %v", resp.Answer[0])
+	}
+}
+
+func mockSpoofThenValidClient(valid *dns.Msg) *client {
+	c := &client{
+		Client: &dns.Client{
+			Net:     "udp",
+			UDPSize: 4096,
+			Dialer:  &net.Dialer{Timeout: time.Second},
+		},
+	}
+	dial := func(network, address string) (net.Conn, error) {
+		clientConn, serverConn := net.Pipe()
+		go func() {
+			defer serverConn.Close()
+			s := &dns.Conn{Conn: serverConn}
+			req, err := s.ReadMsg()
+			if err != nil {
+				return
+			}
+			// A spoofed datagram with the right question but a wrong transaction ID.
+			spoof := valid.Copy()
+			spoof.Id = req.Id ^ 0xFFFF
+			if spoofA, err := dns.NewRR("example.com. 60 IN A 6.6.6.6"); err == nil {
+				spoof.Answer = []dns.RR{spoofA}
+			}
+			_ = s.WriteMsg(spoof)
+			// The genuine answer, echoing the request's transaction ID.
+			out := valid.Copy()
+			out.Id = req.Id
+			_ = s.WriteMsg(out)
 		}()
 		return clientConn, nil
 	}


### PR DESCRIPTION
## Problem

The plain-DNS forwarder (`nameServer`) sent the caller's query verbatim and returned the first datagram it read back, with **no check that the response matched the request**. Two consequences:

- A spoofed or stray datagram delivered to the socket was accepted as the answer (no transaction-ID match, no question match).
- The upstream query reused the **client-chosen** transaction ID, so an off-path attacker did not even have to guess it.

This is the classic cache-poisoning surface for a forwarding resolver.

## Fix

- Send each upstream query with a freshly randomized transaction ID (`dns.Id()`), on a **copy** of the message so the caller's query is never mutated.
- Read in a loop until a datagram whose **ID and question (name/type/class, case-insensitive per RFC 4343) match** the query arrives, or the deadline fires — discarding unsolicited/mismatched datagrams.
- Restore the caller's original transaction ID on the returned reply (so the listener still answers the client with the expected ID).

The UDP→TCP truncation fallback is preserved.

## Tests

- `TestResponseMatchesQuery` — matcher accepts a valid reply and rejects mismatched ID / name / qtype; case-insensitive name match.
- `TestNameServerSkipsSpoofedThenAcceptsValid` — a datagram with the right question but a wrong ID is discarded and the genuine answer is accepted.
- Updated the existing truncation-fallback mock to echo the request ID, as a real server does.

`go build/vet/test ./...` green; `go test -race ./...` clean. Verified end-to-end against real upstreams over UDP/TCP/DoT.