### PR TITLE
fix(dns64): stop mutating the caller query, masking failures, and panicking

### DIFF
--- a/internal/upstream/resolvers/dns64/types.go
+++ b/internal/upstream/resolvers/dns64/types.go
@@ -28,38 +28,53 @@ func (d *DNS64) Resolve(query *dns.Msg, depth int) (*dns.Msg, error) {
 	if depth < 0 {
 		return nil, resolver.ErrLoopDetected
 	}
-	switch qType := query.Question[0].Qtype; qType {
-	case dns.TypeAAAA:
-		if d.IgnoreExistingAAAA {
-			return d.dns64(query, depth)
-		} else {
-			reply, err := d.Resolver.Resolve(query, depth-1)
-			if err != nil || !isNoErrorReply(reply) || !hasAAAA(reply) {
-				return d.dns64(query, depth)
-			}
-			return reply, nil
-		}
-	default:
+	if len(query.Question) == 0 {
+		return nil, resolver.ErrNotSupportedQuestion
+	}
+	if query.Question[0].Qtype != dns.TypeAAAA {
 		return d.Resolver.Resolve(query, depth-1)
 	}
-}
-
-func (d *DNS64) dns64(query *dns.Msg, depth int) (*dns.Msg, error) {
-	query.Question[0].Qtype = dns.TypeA
+	if d.IgnoreExistingAAAA {
+		return d.synthesize(query, depth)
+	}
 	reply, err := d.Resolver.Resolve(query, depth-1)
-	query.Question[0].Qtype = dns.TypeAAAA
 	if err != nil {
 		return nil, err
 	}
-	reply.Question[0].Qtype = dns.TypeAAAA
-	if isNoErrorReply(reply) {
-		for i := range reply.Answer {
-			if a, ok := reply.Answer[i].(*dns.A); ok {
-				reply.Answer[i] = d.aToAAAA(a)
+	// Only synthesize on an authoritative "no AAAA records" answer (NOERROR with no
+	// AAAA). SERVFAIL/REFUSED/NXDOMAIN and existing AAAA are returned unchanged, so
+	// DNS64 never masks an upstream or DNSSEC failure with a synthesized address.
+	if reply == nil || !isNoErrorReply(reply) || hasAAAA(reply) {
+		return reply, nil
+	}
+	return d.synthesize(query, depth)
+}
+
+// synthesize resolves the A records for the query name and rewrites them as AAAA
+// records under the DNS64 prefix. It operates on copies so neither the caller's
+// query nor the upstream resolver's response is mutated.
+func (d *DNS64) synthesize(query *dns.Msg, depth int) (*dns.Msg, error) {
+	aQuery := query.Copy()
+	aQuery.Question[0].Qtype = dns.TypeA
+	reply, err := d.Resolver.Resolve(aQuery, depth-1)
+	if err != nil {
+		return nil, err
+	}
+	if reply == nil {
+		return nil, nil
+	}
+	out := reply.Copy()
+	if len(out.Question) > 0 {
+		out.Question[0].Qtype = dns.TypeAAAA
+	}
+	if isNoErrorReply(out) {
+		for i := range out.Answer {
+			if a, ok := out.Answer[i].(*dns.A); ok {
+				out.Answer[i] = d.aToAAAA(a)
 			}
 		}
 	}
-	return reply, nil
+	return out, nil
 }
 
 func (d *DNS64) aToAAAA(a *dns.A) *dns.AAAA {

--- a/internal/upstream/resolvers/dns64/types_test.go
+++ b/internal/upstream/resolvers/dns64/types_test.go
@@ -176,3 +176,51 @@ func TestDNS64DepthLimit(t *testing.T) {
 		t.Fatalf("expected ErrLoopDetected, got %v", err)
 	}
 }
+
+func TestDNS64DoesNotSynthesizeOnServfail(t *testing.T) {
+	servfail := new(dns.Msg)
+	servfail.SetQuestion("svc.example.", dns.TypeAAAA)
+	servfail.Response = true
+	servfail.Rcode = dns.RcodeServerFailure
+	upstream := &fakeResolver{response: servfail}
+	res := &DNS64{Resolver: upstream, Prefix: net.ParseIP("64:ff9b::")}
+
+	query := new(dns.Msg)
+	query.SetQuestion("svc.example.", dns.TypeAAAA)
+	resp, err := res.Resolve(query, 4)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if resp == nil || resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("expected SERVFAIL to pass through unchanged, got %v", resp)
+	}
+	if upstream.calls != 1 {
+		t.Fatalf("expected no A fallback on SERVFAIL, got %d upstream calls", upstream.calls)
+	}
+}
+
+func TestDNS64DoesNotMutateCallerQuery(t *testing.T) {
+	a := &dns.A{
+		Hdr: dns.RR_Header{Name: "x.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+		A:   net.IP{192, 0, 2, 1},
+	}
+	upstream := &fakeResolver{response: newAResponse("x.example.", a)}
+	res := &DNS64{Resolver: upstream, Prefix: net.ParseIP("64:ff9b::")}
+
+	query := new(dns.Msg)
+	query.SetQuestion("x.example.", dns.TypeAAAA)
+	if _, err := res.Resolve(query, 4); err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if query.Question[0].Qtype != dns.TypeAAAA {
+		t.Fatalf("caller query qtype was mutated to %d", query.Question[0].Qtype)
+	}
+}
+
+func TestDNS64EmptyQuestionReturnsError(t *testing.T) {
+	res := &DNS64{Resolver: &fakeResolver{}, Prefix: net.ParseIP("64:ff9b::")}
+	query := new(dns.Msg) // no question section
+	if _, err := res.Resolve(query, 4); err == nil {
+		t.Fatalf("expected an error for a query with no question, got nil")
+	}
+}


### PR DESCRIPTION
## Problem

Three defects in the DNS64 resolver:

1. **Process crash.** `Resolve` dereferenced `query.Question[0]` with no length check; a query carrying no question panics, and the listeners have no `recover()`.
2. **Data race / caller mutation.** The synthesis path rewrote `query.Question[0].Qtype` in place, which races when the same `*dns.Msg` is shared across resolvers (e.g. under `concurrentNameServerList`).
3. **Masked failures.** AAAA replies that were `SERVFAIL`/`REFUSED`/`NXDOMAIN` fell through to A synthesis, masking upstream and DNSSEC failures with a synthesized address (contrary to RFC 6147 — synthesis is for the NOERROR/no-AAAA case).

## Fix

- Guard the empty-question case (return `ErrNotSupportedQuestion`).
- Synthesize on **copies** of both the query and the upstream reply, so neither the caller's message nor the upstream resolver's response is mutated.
- Only synthesize when the AAAA reply is `NOERROR` with no AAAA records; pass `SERVFAIL`/`REFUSED`/`NXDOMAIN` and existing-AAAA replies through unchanged.

## Tests

Added: SERVFAIL is passed through (no A fallback); caller query qtype is unchanged after `Resolve`; empty-question query returns an error instead of panicking. Existing synthesis/passthrough/ignore-existing tests still pass.

`go build/vet/test ./...` green; `go test -race ./...` clean.