### PR TITLE
fix(nameserver): accept header-only error replies; bound the read loop

### DIFF
--- a/internal/upstream/resolvers/nameserver/errors.go
+++ b/internal/upstream/resolvers/nameserver/errors.go
@@ -1,0 +1,8 @@
+package nameserver
+
+import "errors"
+
+// ErrNoMatchingResponse is returned when the upstream sends only unsolicited or
+// mismatched datagrams (wrong transaction ID or question) and no response matching
+// the outstanding query arrives within the bounded number of read attempts.
+var ErrNoMatchingResponse = errors.New("nameserver: no matching response from upstream")

--- a/internal/upstream/resolvers/nameserver/types.go
+++ b/internal/upstream/resolvers/nameserver/types.go
@@ -122,8 +122,11 @@ func (ns *NameServer) queryWithProtocol(query *dns.Msg, address string, protocol
 	}
 	// Read until a response that matches the query (transaction ID + question)
 	// arrives or the deadline fires, discarding unsolicited or mismatched datagrams
-	// so a forged or stray packet cannot be accepted as the answer.
-	for {
+	// so a forged or stray packet cannot be accepted as the answer. A bounded number
+	// of mismatches is tolerated so a flood of spoofed datagrams cannot spin the CPU
+	// for the entire deadline window.
+	const maxMismatchedResponses = 8
+	for mismatches := 0; ; mismatches++ {
 		msg, err := connection.ReadMsg()
 		if err != nil {
 			return nil, err
@@ -131,15 +134,26 @@ func (ns *NameServer) queryWithProtocol(query *dns.Msg, address string, protocol
 		if responseMatchesQuery(msg, query) {
 			return msg, nil
 		}
+		if mismatches >= maxMismatchedResponses {
+			return nil, ErrNoMatchingResponse
+		}
 	}
 }
 
 // responseMatchesQuery reports whether resp is a plausible answer to query: the
-// transaction ID and the question section (name/type/class) must match. Name
-// comparison is case-insensitive per RFC 4343.
+// transaction ID must match, and either the question section (name/type/class, name
+// compared case-insensitively per RFC 4343) is echoed, or the response is a
+// header-only error reply that omits the question. Servers commonly return
+// FORMERR/SERVFAIL/REFUSED/NOTIMP without echoing the question, so rejecting those
+// would stall the query until the deadline instead of surfacing the error.
 func responseMatchesQuery(resp, query *dns.Msg) bool {
 	if resp == nil || resp.Id != query.Id {
 		return false
+	}
+	if len(resp.Question) == 0 {
+		// Accept only an error reply with no question; a question-less NOERROR
+		// carries no usable answer and could be a spoofed empty success.
+		return resp.Rcode != dns.RcodeSuccess
 	}
 	if len(resp.Question) != len(query.Question) {
 		return false

--- a/internal/upstream/resolvers/nameserver/types_test.go
+++ b/internal/upstream/resolvers/nameserver/types_test.go
@@ -206,3 +206,83 @@ func mockSpoofThenValidClient(valid *dns.Msg) *client {
 	c.dialTLSFunc = dial
 	return c
 }
+
+func TestResponseMatchesQueryHeaderOnlyError(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	q.Id = 0x4242
+
+	servfail := new(dns.Msg)
+	servfail.Id = q.Id
+	servfail.Response = true
+	servfail.Rcode = dns.RcodeServerFailure
+	if !responseMatchesQuery(servfail, q) {
+		t.Fatalf("header-only SERVFAIL with matching ID should be accepted")
+	}
+
+	emptyOK := new(dns.Msg)
+	emptyOK.Id = q.Id
+	emptyOK.Response = true // NOERROR, no question
+	if responseMatchesQuery(emptyOK, q) {
+		t.Fatalf("header-only NOERROR with no question should be rejected")
+	}
+
+	badID := new(dns.Msg)
+	badID.Id = q.Id ^ 0xFFFF
+	badID.Response = true
+	badID.Rcode = dns.RcodeServerFailure
+	if responseMatchesQuery(badID, q) {
+		t.Fatalf("header-only error with wrong ID should be rejected")
+	}
+}
+
+// TestNameServerReturnsHeaderOnlyServfail verifies that an error reply which omits
+// the question (as many servers send) is surfaced immediately rather than being
+// discarded until the deadline.
+func TestNameServerReturnsHeaderOnlyServfail(t *testing.T) {
+	query := new(dns.Msg)
+	query.SetQuestion("example.com.", dns.TypeA)
+
+	ns := &NameServer{
+		Protocol:     "udp",
+		Address:      net.IPv4(127, 0, 0, 1),
+		Port:         53,
+		QueryTimeout: time.Second,
+	}
+	ns.queryClient = mockHeaderOnlyServfailClient()
+	ns.initOnce.Do(func() {})
+
+	resp, err := ns.Resolve(query, 5)
+	if err != nil {
+		t.Fatalf("Resolve returned error: %v", err)
+	}
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("expected SERVFAIL to pass through, got %s", dns.RcodeToString[resp.Rcode])
+	}
+}
+
+func mockHeaderOnlyServfailClient() *client {
+	c := &client{
+		Client: &dns.Client{Net: "udp", UDPSize: 4096, Dialer: &net.Dialer{Timeout: time.Second}},
+	}
+	dial := func(network, address string) (net.Conn, error) {
+		clientConn, serverConn := net.Pipe()
+		go func() {
+			defer serverConn.Close()
+			s := &dns.Conn{Conn: serverConn}
+			req, err := s.ReadMsg()
+			if err != nil {
+				return
+			}
+			out := new(dns.Msg)
+			out.Id = req.Id
+			out.Response = true
+			out.Rcode = dns.RcodeServerFailure // header-only: no question echoed
+			_ = s.WriteMsg(out)
+		}()
+		return clientConn, nil
+	}
+	c.dialFunc = dial
+	c.dialTLSFunc = dial
+	return c
+}


### PR DESCRIPTION
## Problem
The upstream response matcher (added in v1.3.10) required the server to echo the question section. But servers commonly return **FORMERR/SERVFAIL/REFUSED/NOTIMP as a header-only reply with no question**. Those replies were discarded, so the query **stalled until the deadline** instead of surfacing the error promptly.

## Fix
- Accept a question-less reply when its transaction ID matches **and** it is an error rcode. A question-less `NOERROR` is still rejected (it carries no usable answer and could be a spoofed empty success).
- Bound the number of tolerated mismatches (`ErrNoMatchingResponse` after 8) so a flood of spoofed datagrams on the connected socket cannot spin the CPU for the entire deadline window.

## Tests
`TestResponseMatchesQueryHeaderOnlyError` (header-only SERVFAIL accepted; header-only NOERROR and wrong-ID rejected) and `TestNameServerReturnsHeaderOnlyServfail` (end-to-end: a question-less SERVFAIL is surfaced, not timed out). Builds, vets, full suite + `-race` clean.