### PR TITLE
fix(dns64): do not advertise DNSSEC authentication for synthesized AAAA

### DIFF
--- a/internal/upstream/resolvers/dns64/types.go
+++ b/internal/upstream/resolvers/dns64/types.go
@@ -68,12 +68,24 @@ func (d *DNS64) synthesize(query *dns.Msg, depth int) (*dns.Msg, error) {
 		out.Question[0].Qtype = dns.TypeAAAA
 	}
 	if isNoErrorReply(out) {
-		for i := range out.Answer {
-			if a, ok := out.Answer[i].(*dns.A); ok {
-				out.Answer[i] = d.aToAAAA(a)
+		// Rewrite A records as synthesized AAAA and drop the A RRset's signatures:
+		// those RRSIGs cover the A records, not the synthesized AAAA, and synthesized
+		// data cannot be DNSSEC-authenticated (RFC 6147 section 5.5).
+		filtered := out.Answer[:0]
+		for _, rr := range out.Answer {
+			switch v := rr.(type) {
+			case *dns.A:
+				filtered = append(filtered, d.aToAAAA(v))
+			case *dns.RRSIG:
+				// drop signatures over the original A RRset
+			default:
+				filtered = append(filtered, rr)
 			}
 		}
+		out.Answer = filtered
 	}
+	// Never advertise DNSSEC authentication for a synthesized response.
+	out.AuthenticatedData = false
 	return out, nil
 }
 

--- a/internal/upstream/resolvers/dns64/types_test.go
+++ b/internal/upstream/resolvers/dns64/types_test.go
@@ -224,3 +224,44 @@ func TestDNS64EmptyQuestionReturnsError(t *testing.T) {
 		t.Fatalf("expected an error for a query with no question, got nil")
 	}
 }
+
+func TestDNS64SynthesisStripsSignaturesAndAD(t *testing.T) {
+	a := &dns.A{
+		Hdr: dns.RR_Header{Name: "svc.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+		A:   net.IP{192, 0, 2, 9},
+	}
+	sig := &dns.RRSIG{
+		Hdr:         dns.RR_Header{Name: "svc.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 60},
+		TypeCovered: dns.TypeA, Algorithm: 13, Labels: 2, OrigTtl: 60,
+		Expiration:  2000000000, Inception: 1000000000, KeyTag: 12345,
+		SignerName:  "example.", Signature: "aGVsbG8=",
+	}
+	resp := newAResponse("svc.example.", a, sig)
+	resp.AuthenticatedData = true
+
+	res := &DNS64{Resolver: &fakeResolver{response: resp}, Prefix: net.ParseIP("64:ff9b::")}
+	query := new(dns.Msg)
+	query.SetQuestion("svc.example.", dns.TypeAAAA)
+	out, err := res.Resolve(query, 4)
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if out.AuthenticatedData {
+		t.Fatalf("synthesized response must not set the AD bit (RFC 6147 5.5)")
+	}
+	var aaaa, rrsig int
+	for _, rr := range out.Answer {
+		switch rr.(type) {
+		case *dns.AAAA:
+			aaaa++
+		case *dns.RRSIG:
+			rrsig++
+		}
+	}
+	if aaaa != 1 {
+		t.Fatalf("expected 1 synthesized AAAA, got %d", aaaa)
+	}
+	if rrsig != 0 {
+		t.Fatalf("synthesized response must not retain RRSIG records, got %d", rrsig)
+	}
+}


### PR DESCRIPTION
## Problem
A synthesized AAAA response carried over the upstream A answer's **RRSIG records and AD=1**, advertising DNSSEC-authenticated data for records that were synthesized locally and were never signed as AAAA. The A-record RRSIGs do not cover the synthesized AAAA, and synthesized data cannot be authenticated (RFC 6147 §5.5).

## Fix
On synthesis: drop the A RRset's RRSIG records from the answer (keep CNAMEs etc.), and clear the AD bit on the synthesized response.

## Tests
`TestDNS64SynthesisStripsSignaturesAndAD`: an upstream A answer with an RRSIG and AD=1 yields a synthesized AAAA with no RRSIG and AD=0. Existing synthesis/passthrough tests still pass. Builds, vets, `-race` clean.