### PR TITLE
fix(dnsServer): truncate oversized UDP responses (TC=1) and guard nil replies

### DIFF
--- a/internal/listeners/servers/dns/server/truncate_test.go
+++ b/internal/listeners/servers/dns/server/truncate_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestUDPSize(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	if got := udpSize(q); got != dns.MinMsgSize {
+		t.Fatalf("no-EDNS udpSize = %d, want %d", got, dns.MinMsgSize)
+	}
+
+	q2 := new(dns.Msg)
+	q2.SetQuestion("example.com.", dns.TypeA)
+	q2.SetEdns0(4096, false)
+	if got := udpSize(q2); got != 4096 {
+		t.Fatalf("EDNS udpSize = %d, want 4096", got)
+	}
+
+	q3 := new(dns.Msg)
+	q3.SetQuestion("example.com.", dns.TypeA)
+	q3.SetEdns0(200, false) // below the 512 floor
+	if got := udpSize(q3); got != dns.MinMsgSize {
+		t.Fatalf("small-EDNS udpSize = %d, want %d", got, dns.MinMsgSize)
+	}
+}
+
+func TestClampUDPResponseTruncatesOversized(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA) // no EDNS -> 512-octet limit
+
+	reply := new(dns.Msg)
+	reply.SetReply(q)
+	for i := 0; i < 50; i++ {
+		reply.Answer = append(reply.Answer, &dns.TXT{
+			Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 60},
+			Txt: []string{"a-reasonably-long-txt-record-value-used-to-inflate-the-message-size"},
+		})
+	}
+	if reply.Len() <= dns.MinMsgSize {
+		t.Fatalf("test setup: reply not large enough (%d octets)", reply.Len())
+	}
+	origAnswers := len(reply.Answer)
+
+	out := clampUDPResponse(reply, q)
+	if !out.Truncated {
+		t.Fatalf("expected the TC bit to be set on the clamped response")
+	}
+	if out.Len() > dns.MinMsgSize {
+		t.Fatalf("clamped response is %d octets, exceeds %d", out.Len(), dns.MinMsgSize)
+	}
+	if reply.Truncated || len(reply.Answer) != origAnswers {
+		t.Fatalf("the original (possibly shared) reply was mutated: truncated=%v answers=%d", reply.Truncated, len(reply.Answer))
+	}
+}
+
+func TestClampUDPResponseLeavesSmallUnchanged(t *testing.T) {
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	reply := new(dns.Msg)
+	reply.SetReply(q)
+	a, err := dns.NewRR("example.com. 60 IN A 93.184.216.34")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	reply.Answer = []dns.RR{a}
+
+	out := clampUDPResponse(reply, q)
+	if out != reply {
+		t.Fatalf("a small reply should be returned as-is without copying")
+	}
+	if out.Truncated {
+		t.Fatalf("a small reply should not be marked truncated")
+	}
+}

--- a/internal/listeners/servers/dns/server/types.go
+++ b/internal/listeners/servers/dns/server/types.go
@@ -31,8 +31,43 @@ func (d *DNSServer) Serve(handler func(query *dns.Msg) (reply *dns.Msg), errorHa
 		return
 	}
 	handleIfError(dns.ListenAndServe(net.JoinHostPort(d.Listen.String(), strconv.Itoa(int(d.Port))), d.Protocol, dns.HandlerFunc(func(w dns.ResponseWriter, query *dns.Msg) {
-		handleIfError(w.WriteMsg(handler(query)), errorHandler)
+		reply := handler(query)
+		if reply == nil {
+			reply = new(dns.Msg)
+			reply.SetRcode(query, dns.RcodeServerFailure)
+		}
+		if d.Protocol == "udp" {
+			reply = clampUDPResponse(reply, query)
+		}
+		handleIfError(w.WriteMsg(reply), errorHandler)
 	})), errorHandler)
+}
+
+// clampUDPResponse returns reply truncated (TC=1) to the requestor's advertised UDP
+// payload size so secDNS never emits an oversized UDP datagram (a reflection /
+// amplification vector). It only copies-and-truncates when the reply actually
+// exceeds the limit, leaving the common case — and any shared/cached message — alone.
+func clampUDPResponse(reply *dns.Msg, query *dns.Msg) *dns.Msg {
+	max := udpSize(query)
+	if reply.Len() <= max {
+		return reply
+	}
+	out := reply.Copy()
+	out.Truncate(max)
+	return out
+}
+
+// udpSize is the maximum UDP payload the requestor will accept: the EDNS0 advertised
+// size (floored at the 512-octet minimum), or 512 when the query carries no OPT.
+func udpSize(query *dns.Msg) int {
+	if query != nil {
+		if opt := query.IsEdns0(); opt != nil {
+			if size := int(opt.UDPSize()); size > dns.MinMsgSize {
+				return size
+			}
+		}
+	}
+	return dns.MinMsgSize
 }
 
 func handleIfError(err error, errorHandler func(err error)) {


### PR DESCRIPTION
## Problem
The UDP listener wrote replies verbatim, so an answer larger than the requestor's EDNS buffer (or 512 octets without EDNS) was emitted as an **oversized UDP datagram** — a reflection/amplification vector. A `nil` handler reply was also passed straight to `WriteMsg`.

## Fix
- For UDP listeners, truncate the reply to the requestor's advertised size with the **TC bit set** (client retries over TCP). Copy-then-truncate, and only when the reply actually exceeds the limit, so the common case — and any shared/cached `*dns.Msg` — is never mutated.
- Synthesize `SERVFAIL` for a nil handler reply instead of passing `nil` to `WriteMsg`.

## Tests
`TestUDPSize`, `TestClampUDPResponseTruncatesOversized` (TC set, fits the limit, original message unmutated), `TestClampUDPResponseLeavesSmallUnchanged` (small reply returned as-is). Builds, vets, `-race` clean.