### PR TITLE
fix(httpAPIServer): add server timeouts, body limit, and name-length cap

### DIFF
--- a/internal/listeners/servers/http/api/server/errors.go
+++ b/internal/listeners/servers/http/api/server/errors.go
@@ -5,6 +5,7 @@ import "errors"
 var (
 	ErrNilHandler        = errors.New("listeners/servers/http/api/server: nil handler")
 	ErrMissingName       = errors.New("listeners/servers/http/api/server: missing name parameter")
+	ErrNameTooLong       = errors.New("listeners/servers/http/api/server: name exceeds 255 octets")
 	ErrUnsupportedMethod = errors.New("listeners/servers/http/api/server: unsupported method")
 	errNilReply          = errors.New("listeners/servers/http/api/server: nil reply from handler")
 )

--- a/internal/listeners/servers/http/api/server/types.go
+++ b/internal/listeners/servers/http/api/server/types.go
@@ -12,7 +12,13 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
+
+// maxRequestBodyBytes bounds the request body the /resolve endpoint will read, so a
+// slow or oversized body cannot exhaust memory. A DNS query payload is tiny; 64 KiB
+// is generous.
+const maxRequestBodyBytes = 64 << 10
 
 type HTTPAPIServer struct {
 	Listen net.IP
@@ -40,8 +46,13 @@ func (h *HTTPAPIServer) Serve(handler func(query *dns.Msg) (reply *dns.Msg), err
 		h.handleResolve(w, r, handler, errorHandler)
 	})
 	srv := &http.Server{
-		Addr:    net.JoinHostPort(h.Listen.String(), strconv.Itoa(int(h.Port))),
-		Handler: mux,
+		Addr:              net.JoinHostPort(h.Listen.String(), strconv.Itoa(int(h.Port))),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    8 << 10,
 	}
 	handleIfError(srv.ListenAndServe(), errorHandler)
 }
@@ -66,6 +77,7 @@ type queryRequest struct {
 }
 
 func (h *HTTPAPIServer) handleResolve(w http.ResponseWriter, r *http.Request, handler func(query *dns.Msg) (reply *dns.Msg), errorHandler func(err error)) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	req, err := h.parseRequest(r)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err)
@@ -148,8 +160,6 @@ func (h *HTTPAPIServer) parseRequest(r *http.Request) (queryRequest, error) {
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				return queryRequest{}, err
 			}
-			req.Raw = req.Raw
-			req.Simple = req.Simple
 			return validateRequest(req)
 		}
 		if err := r.ParseForm(); err != nil {
@@ -189,6 +199,11 @@ func validateRequest(req queryRequest) (queryRequest, error) {
 	req.Name = strings.TrimSpace(req.Name)
 	if req.Name == "" {
 		return queryRequest{}, ErrMissingName
+	}
+	// A DNS name is at most 255 octets on the wire; reject anything longer up front
+	// so an oversized name cannot drive superlinear work in downstream rule matching.
+	if len(req.Name) > 255 {
+		return queryRequest{}, ErrNameTooLong
 	}
 	return req, nil
 }

--- a/internal/listeners/servers/http/api/server/types_test.go
+++ b/internal/listeners/servers/http/api/server/types_test.go
@@ -336,3 +336,15 @@ func httptestRequest(method, body string, query url.Values) *http.Request {
 	req, _ := http.NewRequest(method, urlStr, bytes.NewBufferString(body))
 	return req
 }
+
+func TestValidateRequestNameLength(t *testing.T) {
+	if _, err := validateRequest(queryRequest{Name: "example.com"}); err != nil {
+		t.Fatalf("valid name rejected: %v", err)
+	}
+	if _, err := validateRequest(queryRequest{Name: strings.Repeat("a", 256)}); err != ErrNameTooLong {
+		t.Fatalf("expected ErrNameTooLong for a 256-octet name, got %v", err)
+	}
+	if _, err := validateRequest(queryRequest{Name: "   "}); err != ErrMissingName {
+		t.Fatalf("expected ErrMissingName for a blank name, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem
The `/resolve` HTTP server had **no Read/Write/Idle/Header timeouts** (Slowloris and connection-exhaustion exposure) and decoded the request body **unbounded** (memory pressure). An unbounded query name also fed superlinear work into downstream rule matching.

## Fix
- Conservative `http.Server` timeouts (`ReadHeaderTimeout` 5s, `ReadTimeout`/`WriteTimeout` 10s, `IdleTimeout` 60s) + `MaxHeaderBytes` 8 KiB.
- Wrap the request body in `http.MaxBytesReader` (64 KiB).
- Reject names longer than 255 octets (a DNS name's wire maximum) up front.
- Remove the dead `req.Raw`/`req.Simple` self-assignments (a `go vet` warning).

## Tests
`TestValidateRequestNameLength` (valid accepted; 256-octet rejected with `ErrNameTooLong`; blank rejected with `ErrMissingName`). Existing handler/parse tests still pass. Builds, vets (now clean), `-race` clean.