### PR TITLE
fix(dnsServer): recover handler panics into SERVFAIL

### DIFF
--- a/internal/listeners/servers/dns/server/recover_test.go
+++ b/internal/listeners/servers/dns/server/recover_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestSafeHandleRecoversPanic(t *testing.T) {
+	var captured error
+	reply := safeHandle(func(*dns.Msg) *dns.Msg { panic("boom") }, new(dns.Msg), func(err error) { captured = err })
+	if reply != nil {
+		t.Fatalf("expected a nil reply after a handler panic, got %v", reply)
+	}
+	if captured == nil {
+		t.Fatalf("expected the error handler to receive the recovered panic")
+	}
+}
+
+func TestSafeHandlePassesThrough(t *testing.T) {
+	want := new(dns.Msg)
+	got := safeHandle(func(*dns.Msg) *dns.Msg { return want }, new(dns.Msg), nil)
+	if got != want {
+		t.Fatalf("safeHandle altered a normal reply")
+	}
+}

--- a/internal/listeners/servers/dns/server/types.go
+++ b/internal/listeners/servers/dns/server/types.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"github.com/miekg/dns"
 	"github.com/zhouchenh/go-descriptor"
 	"github.com/zhouchenh/secDNS/internal/common"
@@ -31,7 +32,7 @@ func (d *DNSServer) Serve(handler func(query *dns.Msg) (reply *dns.Msg), errorHa
 		return
 	}
 	handleIfError(dns.ListenAndServe(net.JoinHostPort(d.Listen.String(), strconv.Itoa(int(d.Port))), d.Protocol, dns.HandlerFunc(func(w dns.ResponseWriter, query *dns.Msg) {
-		reply := handler(query)
+		reply := safeHandle(handler, query, errorHandler)
 		if reply == nil {
 			reply = new(dns.Msg)
 			reply.SetRcode(query, dns.RcodeServerFailure)
@@ -41,6 +42,19 @@ func (d *DNSServer) Serve(handler func(query *dns.Msg) (reply *dns.Msg), errorHa
 		}
 		handleIfError(w.WriteMsg(reply), errorHandler)
 	})), errorHandler)
+}
+
+// safeHandle runs handler(query), converting a panic in the resolver tree into a nil
+// reply so the caller can answer SERVFAIL. miekg's server does not recover handler
+// panics, so without this a single defective code path would crash the whole process.
+func safeHandle(handler func(query *dns.Msg) (reply *dns.Msg), query *dns.Msg, errorHandler func(err error)) (reply *dns.Msg) {
+	defer func() {
+		if r := recover(); r != nil {
+			handleIfError(fmt.Errorf("dnsServer: recovered from handler panic: %v", r), errorHandler)
+			reply = nil
+		}
+	}()
+	return handler(query)
 }
 
 // clampUDPResponse returns reply truncated (TC=1) to the requestor's advertised UDP


### PR DESCRIPTION
## Problem
miekg/dns does not recover panics raised inside the query handler, so a single defective code path anywhere in the resolver tree would **crash the whole server process**.

## Fix
Wrap the handler call in a `recover` that reports via the error handler and falls back to a `SERVFAIL` reply, keeping the listener alive. (The HTTP listener is already protected by `net/http`'s per-request recovery, so this targets the DNS listener only.)

## Tests
`TestSafeHandleRecoversPanic` (panicking handler → nil reply + error handler invoked) and `TestSafeHandlePassesThrough` (normal reply unaffected). Builds, vets, `-race` clean.