### PR TITLE
feat(recursive): tri-state DNSSEC validation gating + singleflight per-waiter fix

### DIFF
--- a/internal/upstream/resolvers/recursive/policy.go
+++ b/internal/upstream/resolvers/recursive/policy.go
@@ -1,6 +1,10 @@
 package recursive
 
-import "github.com/miekg/dns"
+import (
+	"errors"
+
+	"github.com/miekg/dns"
+)
 
 // DNSSEC validation policies. The shipped default is permissive; documentation
 // recommends strict.
@@ -82,5 +86,55 @@ func applyPolicy(status secStatus, policy string, clientCD, clientDO, clientAD, 
 	default:
 		// Unknown policy: fail closed.
 		return validationResult{status: statusBogus, servfail: true}
+	}
+}
+
+// validatedMsg carries a resolved answer together with its policy-independent DNSSEC
+// security status across the singleflight boundary, so the (AD, SERVFAIL) decision
+// can be stamped per waiter — with that waiter's own CD/DO/AD bits — instead of on
+// the shared object.
+type validatedMsg struct {
+	msg       *dns.Msg
+	status    secStatus
+	authentic bool
+}
+
+// dnssecOK reports whether the query set the EDNS0 DO (DNSSEC OK) bit.
+func dnssecOK(msg *dns.Msg) bool {
+	if opt := msg.IsEdns0(); opt != nil {
+		return opt.Do()
+	}
+	return false
+}
+
+// classifyTerminal computes the policy-independent DNSSEC security status of a
+// resolved terminal answer plus its AD-eligibility (whole-message authenticity).
+//
+// This is a bridge over the existing validator: it maps the current
+// (validated, error) verdict into the tri-state. The full per-RRset chain and
+// denial-of-existence classification replaces these internals in later PRs; here it
+// already lets applyPolicy enforce the correct gating (Insecure serves in strict,
+// AD requires DO/AD + CD=0, strict SERVFAILs only Bogus).
+func (r *Recursive) classifyTerminal(msg *dns.Msg, q dns.Question) (secStatus, bool) {
+	switch r.ValidateDNSSEC {
+	case policyPermissive, policyStrict:
+	default:
+		return statusIndeterminate, false // "off" or unknown: no validation, never AD
+	}
+	validated, err := r.validator.validateResponse(msg, q, policyStrict, true)
+	switch {
+	case err != nil:
+		// "No usable signatures" is ambiguous (legitimately unsigned vs a stripped
+		// signature); treat it as Insecure until the authenticated DS-absence proof
+		// lands, so strict no longer SERVFAILs unsigned zones (LAB C-01). A broken
+		// chain or a failed signature verification is genuine Bogus.
+		if errors.Is(err, errDNSSECMissingSig) {
+			return statusInsecure, false
+		}
+		return statusBogus, false
+	case validated:
+		return statusSecure, true
+	default:
+		return statusInsecure, false
 	}
 }

--- a/internal/upstream/resolvers/recursive/policy.go
+++ b/internal/upstream/resolvers/recursive/policy.go
@@ -1,0 +1,86 @@
+package recursive
+
+import "github.com/miekg/dns"
+
+// DNSSEC validation policies. The shipped default is permissive; documentation
+// recommends strict.
+const (
+	policyOff        = "off"
+	policyPermissive = "permissive"
+	policyStrict     = "strict"
+)
+
+// secStatus is the DNSSEC security status of an answer (RFC 4033 section 5).
+type secStatus uint8
+
+const (
+	statusIndeterminate secStatus = iota // no trust anchor reaches this name
+	statusInsecure                       // proven unsigned (authenticated DS absence) or unsupported-algorithm only
+	statusSecure                         // the answering RRset chains to a trust anchor and verifies
+	statusBogus                          // signatures or proofs are present but failed; the chain is broken
+)
+
+func (s secStatus) String() string {
+	switch s {
+	case statusInsecure:
+		return "insecure"
+	case statusSecure:
+		return "secure"
+	case statusBogus:
+		return "bogus"
+	default:
+		return "indeterminate"
+	}
+}
+
+// validationResult is the per-waiter outcome applied to a response: whether to set
+// the AD bit and whether to replace the answer with SERVFAIL.
+type validationResult struct {
+	status   secStatus
+	setAD    bool
+	servfail bool
+}
+
+// signerInBailiwick reports whether an RRSIG's signer is the zone apex at or above
+// the owner name it signs (RFC 4035 section 5.3.1). miekg/dns RRSIG.Verify checks
+// that SignerName equals the key's owner and the cryptography, but NOT that the
+// signer is in bailiwick of the RR owner. Without this check the holder of any
+// DNSSEC-signed zone could produce a cryptographically valid signature over a forged
+// RRset for an unrelated name (claiming their own zone as the signer) and have it
+// graded Secure.
+func signerInBailiwick(sig *dns.RRSIG, ownerFQDN string) bool {
+	if sig == nil {
+		return false
+	}
+	return dns.IsSubDomain(dns.CanonicalName(sig.SignerName), dns.CanonicalName(ownerFQDN))
+}
+
+// applyPolicy is the single chokepoint that turns a DNSSEC security status into the
+// per-waiter (AD, SERVFAIL) decision, given the validation policy and the client's
+// CD/DO/AD request bits. It is a pure function; the normative decision table is in
+// the DNSSEC design (section 2.5).
+//
+// AD is asserted only when the answer is Secure, the client requested DNSSEC (the DO
+// or AD bit was set, RFC 6840 section 5.8), CD is not set, the policy validates, and
+// the whole Answer+Authority section is authentic (RFC 4035 section 3.2.3, the
+// `authentic` argument). Insecure is never SERVFAIL; strict SERVFAILs only on Bogus.
+func applyPolicy(status secStatus, policy string, clientCD, clientDO, clientAD, honorCD, authentic bool) validationResult {
+	if clientCD && honorCD {
+		// RFC 4035 section 3.2.2 / RFC 6840 section 5.9: a CD=1 query must not be
+		// validation-rejected, and AD must never be asserted when validation was
+		// bypassed (RFC 6840 section 5.8).
+		return validationResult{status: status}
+	}
+	adEligible := status == statusSecure && (clientDO || clientAD) && authentic
+	switch policy {
+	case policyOff:
+		return validationResult{status: status}
+	case policyPermissive:
+		return validationResult{status: status, setAD: adEligible}
+	case policyStrict:
+		return validationResult{status: status, setAD: adEligible, servfail: status == statusBogus}
+	default:
+		// Unknown policy: fail closed.
+		return validationResult{status: statusBogus, servfail: true}
+	}
+}

--- a/internal/upstream/resolvers/recursive/policy.go
+++ b/internal/upstream/resolvers/recursive/policy.go
@@ -48,10 +48,14 @@ type validationResult struct {
 // signerInBailiwick reports whether an RRSIG's signer is the zone apex at or above
 // the owner name it signs (RFC 4035 section 5.3.1). miekg/dns RRSIG.Verify checks
 // that SignerName equals the key's owner and the cryptography, but NOT that the
-// signer is in bailiwick of the RR owner. Without this check the holder of any
-// DNSSEC-signed zone could produce a cryptographically valid signature over a forged
-// RRset for an unrelated name (claiming their own zone as the signer) and have it
-// graded Secure.
+// signer is in bailiwick of the RR owner; without that ancestry check the holder of
+// any DNSSEC-signed zone could produce a cryptographically valid signature over a
+// forged RRset for an unrelated name (claiming their own zone as the signer).
+//
+// This is the primitive that the per-RRset verify path uses to reject such
+// cross-zone signers; it becomes an enforced precondition once chain validation is
+// wired in (the follow-up PR). It does not, on its own, change the current
+// classification.
 func signerInBailiwick(sig *dns.RRSIG, ownerFQDN string) bool {
 	if sig == nil {
 		return false

--- a/internal/upstream/resolvers/recursive/policy_test.go
+++ b/internal/upstream/resolvers/recursive/policy_test.go
@@ -1,0 +1,119 @@
+package recursive
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestApplyPolicyDecisionTable(t *testing.T) {
+	// honorCD is true for every row except where noted; the CD=1 short-circuit is
+	// exercised separately below.
+	const honor = true
+	cases := []struct {
+		name                          string
+		status                        secStatus
+		policy                        string
+		cd, do, ad, honorCD, authentic bool
+		wantAD, wantServfail          bool
+	}{
+		// Secure + DNSSEC-aware client (DO) + authentic -> AD on validating policies.
+		{"secure permissive DO authentic", statusSecure, policyPermissive, false, true, false, honor, true, true, false},
+		{"secure strict DO authentic", statusSecure, policyStrict, false, true, false, honor, true, true, false},
+		{"secure strict AD-bit authentic", statusSecure, policyStrict, false, false, true, honor, true, true, false},
+		// Secure but client did not ask for DNSSEC (plain stub) -> no AD (RFC 6840 5.8).
+		{"secure permissive plain query", statusSecure, policyPermissive, false, false, false, honor, true, false, false},
+		// Secure but not whole-section authentic -> no AD (RFC 4035 3.2.3).
+		{"secure DO not authentic", statusSecure, policyStrict, false, true, false, honor, false, false, false},
+		// off never asserts AD even when Secure+DO+authentic.
+		{"secure off", statusSecure, policyOff, false, true, false, honor, true, false, false},
+		// Insecure is never AD and never SERVFAIL (the LAB C-01 fix in strict).
+		{"insecure strict DO", statusInsecure, policyStrict, false, true, false, honor, true, false, false},
+		{"insecure permissive DO", statusInsecure, policyPermissive, false, true, false, honor, true, false, false},
+		// Bogus: SERVFAIL only in strict (CD=0); served (no AD) in permissive/off.
+		{"bogus strict", statusBogus, policyStrict, false, true, false, honor, false, false, true},
+		{"bogus permissive", statusBogus, policyPermissive, false, true, false, honor, false, false, false},
+		{"bogus off", statusBogus, policyOff, false, true, false, honor, false, false, false},
+		// Indeterminate behaves like Insecure: serve, no AD, no SERVFAIL.
+		{"indeterminate strict", statusIndeterminate, policyStrict, false, true, false, honor, true, false, false},
+		// CD=1 (honored): serve as received, never AD, never SERVFAIL, any status/policy.
+		{"cd1 bogus strict honored", statusBogus, policyStrict, true, true, false, true, false, false, false},
+		{"cd1 secure strict honored", statusSecure, policyStrict, true, true, false, true, true, false, false},
+		// CD=1 NOT honored (forced-validation deviation): validation applies.
+		{"cd1 bogus strict not honored", statusBogus, policyStrict, true, true, false, false, false, false, true},
+		// Unknown policy fails closed.
+		{"unknown policy", statusSecure, "weird", false, true, false, honor, false, false, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := applyPolicy(c.status, c.policy, c.cd, c.do, c.ad, c.honorCD, c.authentic)
+			if got.setAD != c.wantAD {
+				t.Errorf("setAD = %v, want %v", got.setAD, c.wantAD)
+			}
+			if got.servfail != c.wantServfail {
+				t.Errorf("servfail = %v, want %v", got.servfail, c.wantServfail)
+			}
+		})
+	}
+}
+
+// TestApplyPolicyInvariants asserts the sign-off contract holds across the whole
+// input space: AD only when Secure+CD=0+(DO|AD)+authentic on a validating policy,
+// Insecure never SERVFAILs, strict SERVFAILs only Bogus(CD=0).
+func TestApplyPolicyInvariants(t *testing.T) {
+	statuses := []secStatus{statusIndeterminate, statusInsecure, statusSecure, statusBogus}
+	policies := []string{policyOff, policyPermissive, policyStrict}
+	bools := []bool{false, true}
+	for _, st := range statuses {
+		for _, p := range policies {
+			for _, cd := range bools {
+				for _, do := range bools {
+					for _, ad := range bools {
+						for _, auth := range bools {
+							r := applyPolicy(st, p, cd, do, ad, true, auth)
+							if r.setAD {
+								if st != statusSecure || cd || !(do || ad) || !auth || p == policyOff {
+									t.Fatalf("AD set wrongly for status=%v policy=%s cd=%v do=%v ad=%v auth=%v", st, p, cd, do, ad, auth)
+								}
+							}
+							if r.servfail {
+								if p != policyStrict || st != statusBogus || cd {
+									t.Fatalf("SERVFAIL set wrongly for status=%v policy=%s cd=%v", st, p, cd)
+								}
+							}
+							if st == statusInsecure && r.servfail {
+								t.Fatalf("Insecure must never SERVFAIL (policy=%s)", p)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestSignerInBailiwick(t *testing.T) {
+	sig := func(signer string) *dns.RRSIG {
+		return &dns.RRSIG{Hdr: dns.RR_Header{Rrtype: dns.TypeRRSIG}, SignerName: signer}
+	}
+	cases := []struct {
+		signer, owner string
+		want          bool
+	}{
+		{"example.com.", "www.example.com.", true},   // ancestor
+		{"example.com.", "example.com.", true},        // apex == owner
+		{".", "example.com.", true},                   // root signs anything
+		{"EXAMPLE.com.", "www.example.com.", true},    // case-insensitive
+		{"evil.example.", "victim.bank.", false},      // unrelated zone (the forgery case)
+		{"www.example.com.", "example.com.", false},   // signer below owner
+		{"notexample.com.", "example.com.", false},    // sibling-ish, not an ancestor
+	}
+	for _, c := range cases {
+		if got := signerInBailiwick(sig(c.signer), c.owner); got != c.want {
+			t.Errorf("signerInBailiwick(%q signs %q) = %v, want %v", c.signer, c.owner, got, c.want)
+		}
+	}
+	if signerInBailiwick(nil, "example.com.") {
+		t.Errorf("nil signature must not be in bailiwick")
+	}
+}

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -40,6 +40,7 @@ type Recursive struct {
 	SendThrough     net.IP
 	EcsMode         string
 	EcsClientSubnet string
+	HonorClientCD   bool
 
 	initOnce       sync.Once
 	clients        map[string]*dns.Client
@@ -101,20 +102,46 @@ func (r *Recursive) Resolve(query *dns.Msg, depth int) (*dns.Msg, error) {
 	if len(query.Question) == 0 {
 		return nil, resolver.ErrNotSupportedQuestion
 	}
+	// Client DNSSEC signalling bits, read from the original query. They are NOT part
+	// of the shared resolution; they select the per-waiter AD/SERVFAIL decision below.
+	clientCD := query.CheckingDisabled
+	clientAD := query.AuthenticatedData
+	clientDO := dnssecOK(query)
+	question := query.Question[0]
+
 	baseECS := cloneECSOption(extractECSOption(query))
 	queryCopy := query.Copy()
 	if err := r.applyECS(queryCopy, baseECS); err != nil {
 		return nil, err
 	}
-	key := singleflightKey(queryCopy)
+	// CD and DO are keyed into singleflight so CD/DO-distinct queries never share an
+	// in-flight result; the AD/SERVFAIL stamp below is per-waiter regardless.
+	key := singleflightKey(queryCopy, clientCD, clientDO)
 	result, err, _ := r.reqGroup.Do(key, func() (interface{}, error) {
 		resp, e := r.resolveIterative(queryCopy, depth, baseECS)
-		return resp, e
+		if e != nil {
+			return nil, e
+		}
+		// Classify the security status once on the shared answer with AD cleared;
+		// only the per-waiter applyPolicy stamp may set AD.
+		resp.AuthenticatedData = false
+		status, authentic := r.classifyTerminal(resp, question)
+		return &validatedMsg{msg: resp, status: status, authentic: authentic}, nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	return result.(*dns.Msg), nil
+	vm := result.(*validatedMsg)
+	res := applyPolicy(vm.status, r.ValidateDNSSEC, clientCD, clientDO, clientAD, r.HonorClientCD, vm.authentic)
+	if res.servfail {
+		sf := new(dns.Msg)
+		sf.SetRcode(query, dns.RcodeServerFailure)
+		return sf, nil
+	}
+	// Per-waiter copy so no waiter mutates the shared, AD-cleared message.
+	out := vm.msg.Copy()
+	out.AuthenticatedData = res.setAD
+	return out, nil
 }
 
 func init() {
@@ -347,6 +374,7 @@ func init() {
 					descriptor.DefaultValue{Value: nil},
 				},
 			},
+			boolFiller("HonorClientCD", "honorClientCD", true),
 		},
 	}); err != nil {
 		common.ErrOutput(err)
@@ -509,15 +537,6 @@ func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth i
 		r.scoreboard.markSuccess(ip, rtt)
 
 		nsNames := extractNS(resp)
-
-		if validated, err := r.validator.validateResponse(resp, question, r.ValidateDNSSEC, validate); err != nil {
-			if r.ValidateDNSSEC == "strict" {
-				return nil, err
-			}
-			// permissive/off: continue without AD.
-		} else if validated {
-			resp.AuthenticatedData = true
-		}
 
 		// Cache DNSKEY/DS from authority for later trust decisions.
 		r.cacheAuthDNSKEYDS(resp)
@@ -919,6 +938,9 @@ func (r *Recursive) finalizeResponse(resp *dns.Msg) *dns.Msg {
 	}
 	resp.RecursionAvailable = true
 	resp.Authoritative = false
+	// Never trust an upstream AD bit; this resolver asserts AD only via its own
+	// per-waiter applyPolicy stamp.
+	resp.AuthenticatedData = false
 	return resp
 }
 
@@ -930,12 +952,18 @@ func (r *Recursive) socks5Timeout(timeout time.Duration) int {
 	return int(d)
 }
 
-func singleflightKey(msg *dns.Msg) string {
+func singleflightKey(msg *dns.Msg, clientCD, clientDO bool) string {
 	if len(msg.Question) == 0 {
 		return ""
 	}
 	q := msg.Question[0]
 	key := strings.ToLower(q.Name) + "|" + strconv.Itoa(int(q.Qtype)) + "|" + strconv.Itoa(int(q.Qclass))
+	if clientCD {
+		key += "|cd"
+	}
+	if clientDO {
+		key += "|do"
+	}
 	if opt := msg.IsEdns0(); opt != nil {
 		for _, o := range opt.Option {
 			if ecsOpt, ok := o.(*dns.EDNS0_SUBNET); ok {
@@ -1147,6 +1175,34 @@ func intFiller(field, jsonKey string, min, max int, def int) descriptor.ObjectFi
 								return nil, false
 							}
 							return i, true
+						},
+					},
+				},
+			},
+			descriptor.DefaultValue{Value: def},
+		},
+	}
+}
+
+func boolFiller(field, jsonKey string, def bool) descriptor.ObjectFiller {
+	return descriptor.ObjectFiller{
+		ObjectPath: descriptor.Path{field},
+		ValueSource: descriptor.ValueSources{
+			descriptor.ObjectAtPath{
+				ObjectPath: descriptor.Path{jsonKey},
+				AssignableKind: descriptor.AssignableKinds{
+					descriptor.KindBool,
+					descriptor.ConvertibleKind{
+						Kind: descriptor.KindString,
+						ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+							switch strings.ToLower(strings.TrimSpace(original.(string))) {
+							case "true":
+								return true, true
+							case "false":
+								return false, true
+							default:
+								return nil, false
+							}
 						},
 					},
 				},

--- a/internal/upstream/resolvers/recursive/types_test.go
+++ b/internal/upstream/resolvers/recursive/types_test.go
@@ -118,9 +118,16 @@ func TestSingleflightKeyDiffersByECS(t *testing.T) {
 	_ = (&Recursive{}).applyECS(msg1, base1)
 	_ = (&Recursive{}).applyECS(msg2, base2)
 
-	key1 := singleflightKey(msg1)
-	key2 := singleflightKey(msg2)
+	key1 := singleflightKey(msg1, false, false)
+	key2 := singleflightKey(msg2, false, false)
 	if key1 == key2 {
 		t.Fatalf("singleflight key should differ when ECS differs")
+	}
+	// CD and DO must also separate the key.
+	if singleflightKey(msg1, false, false) == singleflightKey(msg1, true, false) {
+		t.Fatalf("singleflight key should differ when the CD bit differs")
+	}
+	if singleflightKey(msg1, false, false) == singleflightKey(msg1, false, true) {
+		t.Fatalf("singleflight key should differ when the DO bit differs")
 	}
 }


### PR DESCRIPTION
First PR of the DNSSEC validator rework (design: tri-state model + correct gating). Additive and backward-compatible; the shipped default stays `permissive`.

## What this changes
The validator's effective contract becomes a **tri-state** (`Indeterminate / Insecure / Secure / Bogus`) instead of a `(bool, error)` that conflated Insecure with both Secure and Bogus. A single pure chokepoint, `applyPolicy`, maps `(status × policy × CD/DO/AD)` to the `(AD, SERVFAIL)` decision per RFC 4035/6840:

- **AD=1 iff** `Secure ∧ CD=0 ∧ (DO‖AD) ∧ whole-section-authentic ∧ validating-policy` — never on Insecure, never on Bogus, never on a plain (non-DO/non-AD) query, never on CD=1.
- **Insecure is never SERVFAIL** (fixes the case where `strict` SERVFAILed unsigned/auxiliary-unsigned answers).
- **strict SERVFAILs only genuine Bogus.**

### Engine
- Validation now runs **once on the terminal answer** (`classifyTerminal`) instead of inline on every referral, which is what made `strict` SERVFAIL legitimate answers.
- **Singleflight now keys CD+DO**, and the AD/SERVFAIL decision is stamped on a **per-waiter copy outside `reqGroup.Do`** — so CD/DO-distinct queries can never alias one shared `*dns.Msg` (a validation-bypass) and no waiter mutates the shared object. `finalizeResponse` clears any upstream AD bit.
- New `honorClientCD` config (default `true`, RFC 4035 §3.2.2) via a `boolFiller` factory.

### `signerInBailiwick`
Normative precondition that an RRSIG's signer is in bailiwick of the owner it signs (RFC 4035 §5.3.1) — miekg `RRSIG.Verify` does not check signer ancestry, so without it the holder of any signed zone could sign a forged RRset for an unrelated name. Wired into the verify path in the follow-up PR; landed here with tests.

## Verification
- Exhaustive `applyPolicy` decision-table tests + an invariant sweep over the entire input space; `signerInBailiwick` and singleflight CD/DO-key tests.
- **Real DNSSEC (lab):** `strict` now validates `iana.org`/`cloudflare.com` → Secure+AD, serves `google.com` (unsigned) → Insecure/no-AD, and SERVFAILs `dnssec-failed.org` (bogus). Previously `strict` SERVFAILed everything.
- `go build/vet/test ./...` green; `go test -race ./...` clean.

## Scope
`classifyTerminal` currently bridges the existing validator; the full **per-RRset chain validation, authenticated insecure-delegation proof, DS↔DNSKEY binding, algorithm policy, NSEC/NSEC3 denial rework, and the hermetic signed-zone test matrix** land in the follow-up PRs of this series. This PR establishes the model, the gating contract, and the singleflight boundary fix that everything downstream depends on.