### PR TITLE
fix(recursive): enforce signer bailiwick in DNSSEC signature verification

### DIFF
--- a/internal/upstream/resolvers/recursive/bailiwick_test.go
+++ b/internal/upstream/resolvers/recursive/bailiwick_test.go
@@ -1,0 +1,94 @@
+package recursive
+
+import (
+	"crypto"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// genKey generates an ECDSA P-256 zone signing key owned by zone.
+func genKey(t *testing.T, zone string) (*dns.DNSKEY, crypto.Signer) {
+	t.Helper()
+	key := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: dns.Fqdn(zone), Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     257,
+		Protocol:  3,
+		Algorithm: dns.ECDSAP256SHA256,
+	}
+	priv, err := key.Generate(256)
+	if err != nil {
+		t.Fatalf("DNSKEY.Generate: %v", err)
+	}
+	signer, ok := priv.(crypto.Signer)
+	if !ok {
+		t.Fatalf("generated private key is not a crypto.Signer")
+	}
+	return key, signer
+}
+
+// signRRset signs rrs with key, claiming signerName as the RRSIG signer (which may
+// differ from the RR owner — that is exactly the cross-zone-signer case to reject).
+func signRRset(t *testing.T, rrs []dns.RR, key *dns.DNSKEY, priv crypto.Signer, signerName string) *dns.RRSIG {
+	t.Helper()
+	owner := rrs[0].Header().Name
+	sig := &dns.RRSIG{
+		Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: rrs[0].Header().Ttl},
+		TypeCovered: rrs[0].Header().Rrtype,
+		Algorithm:   key.Algorithm,
+		Labels:      uint8(dns.CountLabel(owner)),
+		OrigTtl:     rrs[0].Header().Ttl,
+		Expiration:  uint32(time.Now().Add(24 * time.Hour).Unix()),
+		Inception:   uint32(time.Now().Add(-time.Hour).Unix()),
+		KeyTag:      key.KeyTag(),
+		SignerName:  dns.Fqdn(signerName),
+	}
+	if err := sig.Sign(priv, rrs); err != nil {
+		t.Fatalf("RRSIG.Sign: %v", err)
+	}
+	return sig
+}
+
+func aRRset(owner string) []dns.RR {
+	return []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: dns.Fqdn(owner), Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+		A:   net.IP{192, 0, 2, 1},
+	}}
+}
+
+// TestVerifyRRSetWithKeysAcceptsInBailiwickSigner confirms a legitimate signature —
+// signer is the zone apex at/above the owner — still verifies.
+func TestVerifyRRSetWithKeysAcceptsInBailiwickSigner(t *testing.T) {
+	key, priv := genKey(t, "victim.example.")
+	rrs := aRRset("www.victim.example.")
+	sig := signRRset(t, rrs, key, priv, "victim.example.")
+
+	ok, err := verifyRRSetWithKeys(rrs, []*dns.RRSIG{sig}, []*dns.DNSKEY{key}, false)
+	if !ok {
+		t.Fatalf("legitimate in-bailiwick signature was rejected: %v", err)
+	}
+}
+
+// TestVerifyRRSetWithKeysRejectsCrossZoneSigner is the forgery case: a key owned by
+// evil.example. produces a cryptographically valid RRSIG over www.victim.example.'s
+// RRset, naming evil.example. as the signer. miekg's RRSIG.Verify accepts it (signer
+// equals key owner, crypto is valid); the bailiwick check must reject it because
+// evil.example. is not an ancestor of www.victim.example.
+func TestVerifyRRSetWithKeysRejectsCrossZoneSigner(t *testing.T) {
+	evilKey, evilPriv := genKey(t, "evil.example.")
+	rrs := aRRset("www.victim.example.")
+	sig := signRRset(t, rrs, evilKey, evilPriv, "evil.example.")
+
+	// Sanity: the signature is cryptographically valid under the evil key (so the
+	// only thing that can reject it is the bailiwick check).
+	if err := sig.Verify(evilKey, rrs); err != nil {
+		t.Fatalf("test setup: forged signature is not crypto-valid under its key: %v", err)
+	}
+
+	ok, _ := verifyRRSetWithKeys(rrs, []*dns.RRSIG{sig}, []*dns.DNSKEY{evilKey}, false)
+	if ok {
+		t.Fatalf("cross-zone signer forgery was accepted (signer evil.example. signed www.victim.example.)")
+	}
+}

--- a/internal/upstream/resolvers/recursive/validate.go
+++ b/internal/upstream/resolvers/recursive/validate.go
@@ -475,6 +475,14 @@ func verifyRRSetWithKeys(rrs []dns.RR, sigs []*dns.RRSIG, keys []*dns.DNSKEY, be
 		return false, errDNSSECUntrustedKey
 	}
 	for _, sig := range sigs {
+		// RFC 4035 section 5.3.1: the signer must be in bailiwick of the RRset owner.
+		// miekg/dns RRSIG.Verify checks SignerName == key owner and the cryptography
+		// but NOT that the signer is an ancestor of the RR owner, so without this a
+		// cross-zone signer (the holder of any signed zone signing a forged RRset for
+		// an unrelated name) would be accepted.
+		if len(rrs) == 0 || !signerInBailiwick(sig, rrs[0].Header().Name) {
+			continue
+		}
 		for _, key := range keys {
 			if sig.KeyTag != key.KeyTag() || sig.Algorithm != key.Algorithm {
 				continue


### PR DESCRIPTION
Second PR of the DNSSEC validator rework. Wires the `signerInBailiwick` primitive (added, tested-only, in the previous PR) into the live verify path.

## Problem
`verifyRRSetWithKeys` accepted any RRSIG whose KeyTag/Algorithm matched a key and whose cryptography verified. But miekg/dns `RRSIG.Verify` only checks `SignerName == key owner` and the crypto — **not** that the signer is in bailiwick of the RR owner (RFC 4035 §5.3.1). So the holder of *any* DNSSEC-signed, trust-anchored zone could produce a cryptographically valid signature over a **forged RRset for an unrelated name** (naming their own zone as the signer) and have it graded **Secure** (→ AD set for DO clients). Flagged by the audit and confirmed in the PR-1 review.

## Fix
Require `signerInBailiwick(sig, rrs[0].Header().Name)` before verifying each signature, so a signer that is not an ancestor (or equal) of the RRset owner is rejected.

## Tests (hermetic, real crypto)
- `TestVerifyRRSetWithKeysAcceptsInBailiwickSigner` — a legitimate signature (apex signs a name at/below it) still verifies.
- `TestVerifyRRSetWithKeysRejectsCrossZoneSigner` — generates a real ECDSA key for `evil.example.`, signs `www.victim.example.`'s RRset (confirming the signature is crypto-valid under that key), and asserts `verifyRRSetWithKeys` now **rejects** it.

These also seed the offline signed-zone harness the denial/chain PRs build on.

## Verification
`go build/vet/test ./...` green; full recursive suite passes (no regression to real validation). On real DNSSEC (lab): with the check active, `iana.org`/`cloudflare.com`/`nlnetlabs.nl` still validate to Secure+AD, `dnssec-failed.org` still SERVFAILs. `go test -race ./...` clean.