### PR TITLE
fix(recursive): bind DS to the DNSKEY that signs the DNSKEY RRset

### DIFF
--- a/internal/upstream/resolvers/recursive/ds_binding_test.go
+++ b/internal/upstream/resolvers/recursive/ds_binding_test.go
@@ -1,0 +1,35 @@
+package recursive
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestBindDSToDNSKEYRejectsUnvouchedSelfSign is the append-extra-key forgery: the
+// DNSKEY RRset contains the legitimate (DS-vouched) key plus an attacker key, but the
+// RRset is self-signed only by the attacker key. The parent DS vouches only for the
+// legitimate key, which did NOT sign the RRset, so the set must be rejected. Checking
+// the DS match and the self-signature independently (the old behavior) accepted it.
+func TestBindDSToDNSKEYRejectsUnvouchedSelfSign(t *testing.T) {
+	realKey, realPriv := genKey(t, "example.")
+	evilKey, evilPriv := genKey(t, "example.")
+	dnskeyRRs := []dns.RR{realKey, evilKey}
+
+	ds := realKey.ToDS(dns.SHA256) // parent vouches ONLY for the real key
+	if ds == nil {
+		t.Fatalf("ToDS returned nil")
+	}
+
+	// DNSKEY RRset signed only by the un-vouched (attacker) key.
+	evilSig := signRRset(t, dnskeyRRs, evilKey, evilPriv, "example.")
+	if bindDSToDNSKEY([]dns.RR{ds}, dnskeyRRs, []*dns.RRSIG{evilSig}, []*dns.DNSKEY{realKey, evilKey}) {
+		t.Fatalf("DNSKEY RRset self-signed only by an un-vouched key was accepted")
+	}
+
+	// Control: the same RRset signed by the DS-vouched key is accepted.
+	realSig := signRRset(t, dnskeyRRs, realKey, realPriv, "example.")
+	if !bindDSToDNSKEY([]dns.RR{ds}, dnskeyRRs, []*dns.RRSIG{realSig}, []*dns.DNSKEY{realKey, evilKey}) {
+		t.Fatalf("DNSKEY RRset signed by the DS-vouched key was rejected")
+	}
+}

--- a/internal/upstream/resolvers/recursive/validate.go
+++ b/internal/upstream/resolvers/recursive/validate.go
@@ -338,11 +338,8 @@ func (v *dnssecValidator) trustedKeys(zone string) (*keyState, error) {
 	if len(dnskeys) == 0 {
 		return nil, errDNSSECNoKeys
 	}
-	if _, err := verifyRRSetWithKeys(dnskeyRRs, dnskeySigs, dnskeys, false); err != nil {
-		return nil, err
-	}
-	if !dsMatchesDNSKEY(dsSet, dnskeys) {
-		return nil, fmt.Errorf("dnssec: ds mismatch for %s", zone)
+	if !bindDSToDNSKEY(dsSet, dnskeyRRs, dnskeySigs, dnskeys) {
+		return nil, fmt.Errorf("dnssec: no DS-vouched key signs the DNSKEY RRset for %s", zone)
 	}
 
 	expiry := rrsetExpiry(dnskeyRRs, dnskeySigs, v.now())
@@ -405,7 +402,13 @@ func rrsetExpiry(rrs []dns.RR, sigs []*dns.RRSIG, now time.Time) time.Time {
 	}
 }
 
-func dsMatchesDNSKEY(dsSet []dns.RR, keys []*dns.DNSKEY) bool {
+// bindDSToDNSKEY reports whether the zone's DNSKEY RRset is vouched for by the
+// parent: some DS must match a key (KeyTag + Algorithm + digest) AND that same key
+// must sign the DNSKEY RRset (RFC 4035 section 5.2). Checking the DS match and the
+// DNSKEY self-signature independently would let an attacker append an extra key,
+// self-sign the DNSKEY RRset with it, and pass both checks while the DS only vouches
+// for the legitimate key. All key-tag matches are tried (RFC 4034 appendix B).
+func bindDSToDNSKEY(dsSet []dns.RR, dnskeyRRs []dns.RR, dnskeySigs []*dns.RRSIG, keys []*dns.DNSKEY) bool {
 	for _, dsRR := range dsSet {
 		ds, ok := dsRR.(*dns.DS)
 		if !ok {
@@ -415,7 +418,11 @@ func dsMatchesDNSKEY(dsSet []dns.RR, keys []*dns.DNSKEY) bool {
 			if ds.KeyTag != k.KeyTag() || ds.Algorithm != k.Algorithm {
 				continue
 			}
-			if generated := k.ToDS(ds.DigestType); generated != nil && strings.EqualFold(generated.Digest, ds.Digest) {
+			gen := k.ToDS(ds.DigestType)
+			if gen == nil || !strings.EqualFold(gen.Digest, ds.Digest) {
+				continue
+			}
+			if vouched, _ := verifyRRSetWithKeys(dnskeyRRs, dnskeySigs, []*dns.DNSKEY{k}, false); vouched {
 				return true
 			}
 		}

--- a/internal/upstream/resolvers/recursive/validate_test.go
+++ b/internal/upstream/resolvers/recursive/validate_test.go
@@ -85,7 +85,7 @@ func TestValidatorDsMismatch(t *testing.T) {
 	t.Logf("ds name=%s sig name=%s", ds.Hdr.Name, dsSig.Hdr.Name)
 	dsSet, dsSigs := extractRRSet(&dns.Msg{Answer: []dns.RR{ds, dsSig}}, dns.TypeDS, "example.")
 	t.Logf("extracted ds %d sigs %d", len(dsSet), len(dsSigs))
-	t.Logf("ds matches child key: %v", dsMatchesDNSKEY([]dns.RR{ds}, []*dns.DNSKEY{childKey}))
+	t.Logf("ds binds child DNSKEY: %v", bindDSToDNSKEY([]dns.RR{ds}, []dns.RR{childKey}, []*dns.RRSIG{dnskeySig}, []*dns.DNSKEY{childKey}))
 	state, stateErr := v.trustedKeys("example.")
 	t.Logf("trustedKeys(example.): state=%+v err=%v", state, stateErr)
 


### PR DESCRIPTION
Third PR of the DNSSEC validator rework.

## Problem
`trustedKeys` verified two things **independently**: that the DNSKEY RRset is self-signed by *some* key in the set, and that *some* key matches the parent DS. An attacker who appends an extra key to a zone's DNSKEY RRset and self-signs the RRset with that appended key passes both checks — the legitimate key satisfies the DS, the appended key satisfies the self-signature — even though the parent vouches only for the legitimate key. RFC 4035 §5.2 requires the DNSKEY RRset to be signed by a key that a matching DS vouches for.

## Fix
Replace `dsMatchesDNSKEY` + the independent self-signature check with `bindDSToDNSKEY`: a DS must match a key (KeyTag + Algorithm + digest) **and that same key must sign the DNSKEY RRset** (trying all key-tag matches per RFC 4034 App. B). `dsMatchesDNSKEY` is removed.

## Tests (hermetic)
`TestBindDSToDNSKEYRejectsUnvouchedSelfSign`: a DNSKEY RRset containing the real (DS-vouched) key plus an attacker key, self-signed **only** by the attacker key, is rejected; the same RRset signed by the DS-vouched key is accepted.

## Verification
Existing validator chain tests still pass (legit chains validate). `go build/vet/test ./...` green; on real DNSSEC (lab) `iana.org`/`cloudflare.com`/`nlnetlabs.nl` still validate to Secure+AD. `go test -race ./...` clean.