### PR TITLE
fix(recursive): treat unsupported-algorithm DS as Insecure, not Bogus

### DIFF
--- a/internal/upstream/resolvers/recursive/ds_binding_test.go
+++ b/internal/upstream/resolvers/recursive/ds_binding_test.go
@@ -33,3 +33,30 @@ func TestBindDSToDNSKEYRejectsUnvouchedSelfSign(t *testing.T) {
 		t.Fatalf("DNSKEY RRset signed by the DS-vouched key was rejected")
 	}
 }
+
+func TestDSSetHasSupportedAlgo(t *testing.T) {
+	mkDS := func(algo, digest uint8) dns.RR {
+		return &dns.DS{
+			Hdr:        dns.RR_Header{Name: "example.", Rrtype: dns.TypeDS, Class: dns.ClassINET},
+			Algorithm:  algo,
+			DigestType: digest,
+			KeyTag:     1234,
+			Digest:     "abcd",
+		}
+	}
+	if !dsSetHasSupportedAlgo([]dns.RR{mkDS(dns.ECDSAP256SHA256, dns.SHA256)}) {
+		t.Fatalf("ECDSAP256SHA256 / SHA256 should be supported")
+	}
+	if dsSetHasSupportedAlgo([]dns.RR{mkDS(252, dns.SHA256)}) {
+		t.Fatalf("unknown signing algorithm should be unsupported")
+	}
+	if dsSetHasSupportedAlgo([]dns.RR{mkDS(dns.ECDSAP256SHA256, 99)}) {
+		t.Fatalf("unknown digest type should be unsupported")
+	}
+	if !dsSetHasSupportedAlgo([]dns.RR{mkDS(252, 99), mkDS(dns.ECDSAP256SHA256, dns.SHA256)}) {
+		t.Fatalf("a supported DS among unsupported ones should count as supported")
+	}
+	if dsSetHasSupportedAlgo(nil) {
+		t.Fatalf("empty DS set should be unsupported")
+	}
+}

--- a/internal/upstream/resolvers/recursive/validate.go
+++ b/internal/upstream/resolvers/recursive/validate.go
@@ -329,6 +329,19 @@ func (v *dnssecValidator) trustedKeys(zone string) (*keyState, error) {
 		return nil, err
 	}
 
+	if !dsSetHasSupportedAlgo(dsSet) {
+		// RFC 6840 section 5.2 / RFC 8624: an authenticated DS RRset whose algorithm
+		// or digest types are all unsupported means the path to the child cannot be
+		// verified; the child zone is treated as unsigned (Insecure), never
+		// Bogus/SERVFAIL.
+		state := &keyState{secure: false, keys: nil, expires: fallbackExpiry(v.now())}
+		if !dsExpiry.IsZero() && dsExpiry.Before(state.expires) {
+			state.expires = dsExpiry
+		}
+		v.storeKeyState(zone, state)
+		return state, nil
+	}
+
 	dnskeyMsg, err := v.resolveDNSKEY(zone)
 	if err != nil {
 		return nil, err
@@ -425,6 +438,41 @@ func bindDSToDNSKEY(dsSet []dns.RR, dnskeyRRs []dns.RR, dnskeySigs []*dns.RRSIG,
 			if vouched, _ := verifyRRSetWithKeys(dnskeyRRs, dnskeySigs, []*dns.DNSKEY{k}, false); vouched {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+// supportedSignAlgos and supportedDSDigests list the DNSSEC signing algorithms and
+// DS digest types this validator can verify (RFC 8624). Anything else makes a zone
+// Insecure (RFC 6840 section 5.2), never Bogus.
+var supportedSignAlgos = map[uint8]bool{
+	dns.RSASHA1:          true,
+	dns.RSASHA1NSEC3SHA1: true,
+	dns.RSASHA256:        true,
+	dns.RSASHA512:        true,
+	dns.ECDSAP256SHA256:  true,
+	dns.ECDSAP384SHA384:  true,
+	dns.ED25519:          true,
+}
+
+var supportedDSDigests = map[uint8]bool{
+	dns.SHA1:   true,
+	dns.SHA256: true,
+	dns.SHA384: true,
+}
+
+// dsSetHasSupportedAlgo reports whether the DS RRset contains at least one DS whose
+// signing algorithm and digest type are both supported. If not, the child zone must
+// be treated as unsigned (RFC 6840 section 5.2).
+func dsSetHasSupportedAlgo(dsSet []dns.RR) bool {
+	for _, rr := range dsSet {
+		ds, ok := rr.(*dns.DS)
+		if !ok {
+			continue
+		}
+		if supportedSignAlgos[ds.Algorithm] && supportedDSDigests[ds.DigestType] {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
Fourth PR of the DNSSEC validator rework.

## Problem
When a zone is delegated with a DS whose signing algorithm or digest type the validator does not support, the path to the child cannot be verified — but the code treated this as a validation failure (Bogus → SERVFAIL in strict), turning a future-algorithm zone into an outage. RFC 6840 §5.2 / RFC 8624 require treating such a zone as **unsigned (Insecure)**.

## Fix
After the DS RRset is authenticated, if no DS has both a supported signing algorithm and a supported digest type (`dsSetHasSupportedAlgo`), return an insecure key state — the zone is served (no AD), never SERVFAIL'd.

## Tests
`TestDSSetHasSupportedAlgo` covers supported / unsupported-algorithm / unsupported-digest / mixed / empty. Existing chain tests (ECDSAP256/SHA256, supported) unaffected.

`go build/vet/test ./...` green; `go test -race ./...` clean.