### PR TITLE
fix(recursive): NSEC3 parameter gate and exact-match NODATA proofs

### DIFF
--- a/internal/upstream/resolvers/recursive/denial_test.go
+++ b/internal/upstream/resolvers/recursive/denial_test.go
@@ -1,0 +1,98 @@
+package recursive
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestNSEC3ParamsUsable(t *testing.T) {
+	mk := func(hash uint8, iter uint16, salt string) *dns.NSEC3 {
+		return &dns.NSEC3{Hash: hash, Iterations: iter, Salt: salt}
+	}
+	if !nsec3ParamsUsable([]*dns.NSEC3{mk(dns.SHA1, 50, "ab")}, 100) {
+		t.Fatalf("SHA-1 with iterations within the cap should be usable")
+	}
+	if nsec3ParamsUsable([]*dns.NSEC3{mk(dns.SHA1, 150, "ab")}, 100) {
+		t.Fatalf("iterations above the cap must be unusable (CPU-DoS gate)")
+	}
+	if nsec3ParamsUsable([]*dns.NSEC3{mk(2, 0, "ab")}, 100) {
+		t.Fatalf("an unknown hash algorithm must be unusable")
+	}
+	if nsec3ParamsUsable([]*dns.NSEC3{mk(dns.SHA1, 0, "ab"), mk(dns.SHA1, 5, "ab")}, 100) {
+		t.Fatalf("mixed iteration counts must be unusable")
+	}
+	if nsec3ParamsUsable([]*dns.NSEC3{mk(dns.SHA1, 0, "ab"), mk(dns.SHA1, 0, "cd")}, 100) {
+		t.Fatalf("mixed salts must be unusable")
+	}
+	if nsec3ParamsUsable(nil, 100) {
+		t.Fatalf("an empty NSEC3 set must be unusable")
+	}
+}
+
+func TestVerifyNSECCoverageNODATAExactMatch(t *testing.T) {
+	nsec := func(owner, next string, types ...uint16) *dns.NSEC {
+		return &dns.NSEC{
+			Hdr:        dns.RR_Header{Name: owner, Rrtype: dns.TypeNSEC, Class: dns.ClassINET},
+			NextDomain: next,
+			TypeBitMap: types,
+		}
+	}
+	// Exact-owner NODATA: AAAA absent, CNAME absent -> proof holds.
+	exact := nsec("www.example.", "x.example.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC)
+	if !verifyNSECCoverage("www.example.", dns.TypeAAAA, dns.RcodeSuccess, []*dns.NSEC{exact}) {
+		t.Fatalf("exact-owner NODATA proof should be accepted")
+	}
+	// A covering (non-owner) NSEC proves non-existence, not NODATA -> must be rejected.
+	covering := nsec("a.example.", "z.example.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC)
+	if verifyNSECCoverage("www.example.", dns.TypeAAAA, dns.RcodeSuccess, []*dns.NSEC{covering}) {
+		t.Fatalf("a covering (non-owner) NSEC must not be accepted as a NODATA proof")
+	}
+	// CNAME present at the exact owner -> the answer should have followed the alias.
+	withCNAME := nsec("www.example.", "x.example.", dns.TypeCNAME, dns.TypeRRSIG, dns.TypeNSEC)
+	if verifyNSECCoverage("www.example.", dns.TypeAAAA, dns.RcodeSuccess, []*dns.NSEC{withCNAME}) {
+		t.Fatalf("NODATA with a CNAME present at the owner must be rejected")
+	}
+	// qtype present -> not NODATA.
+	withType := nsec("www.example.", "x.example.", dns.TypeA, dns.TypeAAAA, dns.TypeRRSIG)
+	if verifyNSECCoverage("www.example.", dns.TypeAAAA, dns.RcodeSuccess, []*dns.NSEC{withType}) {
+		t.Fatalf("NODATA proof must fail when the qtype bit is set")
+	}
+}
+
+func TestVerifyNSEC3CoverageNODATARequiresMatch(t *testing.T) {
+	const salt = "aabbccdd"
+	hashedOwner := func(name string) string {
+		return dns.HashName(name, dns.SHA1, 0, salt) + ".example."
+	}
+	match := &dns.NSEC3{
+		Hdr:        dns.RR_Header{Name: hashedOwner("www.example."), Rrtype: dns.TypeNSEC3, Class: dns.ClassINET},
+		Hash:       dns.SHA1,
+		Iterations: 0,
+		Salt:       salt,
+		TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG},
+	}
+	if !match.Match("www.example.") {
+		t.Skipf("test setup: NSEC3.Match did not hold for the constructed owner")
+	}
+	// Matching NSEC3 with AAAA and CNAME bits clear -> NODATA accepted.
+	if !verifyNSEC3Coverage("www.example.", dns.TypeAAAA, dns.RcodeSuccess, []*dns.NSEC3{match}, 100) {
+		t.Fatalf("a matching NSEC3 NODATA proof should be accepted")
+	}
+	// A record that does not match qname must not prove NODATA (the removed bare-cover bug).
+	nonMatch := &dns.NSEC3{
+		Hdr:        dns.RR_Header{Name: hashedOwner("other.example."), Rrtype: dns.TypeNSEC3, Class: dns.ClassINET},
+		Hash:       dns.SHA1,
+		Iterations: 0,
+		Salt:       salt,
+		TypeBitMap: []uint16{dns.TypeA},
+	}
+	if verifyNSEC3Coverage("www.example.", dns.TypeAAAA, dns.RcodeSuccess, []*dns.NSEC3{nonMatch}, 100) {
+		t.Fatalf("a non-matching NSEC3 must not prove NODATA")
+	}
+	// Over-cap iterations -> rejected by the parameter gate even though it would match.
+	overcap := &dns.NSEC3{Hdr: match.Hdr, Hash: dns.SHA1, Iterations: 5000, Salt: salt, TypeBitMap: match.TypeBitMap}
+	if verifyNSEC3Coverage("www.example.", dns.TypeAAAA, dns.RcodeSuccess, []*dns.NSEC3{overcap}, 100) {
+		t.Fatalf("an over-cap NSEC3 must be rejected by the iteration gate")
+	}
+}

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -22,25 +22,26 @@ import (
 // Recursive is a placeholder for a full recursive, DNSSEC-validating resolver.
 // It is scaffolded now to wire descriptors, defaults, and root hints; recursion and validation will be implemented in follow-up steps.
 type Recursive struct {
-	RootServers     []RootServer
-	ValidateDNSSEC  string
-	QNameMinimize   bool
-	EDNSSize        uint16
-	Timeout         time.Duration
-	Retries         int
-	ProbeTopN       int
-	ProbeInterval   time.Duration
-	PreferIPv6      bool
-	MaxDepth        int
-	MaxCNAME        int
-	MaxReferrals    int
-	Socks5Proxy     string
-	Socks5Username  string
-	Socks5Password  string
-	SendThrough     net.IP
-	EcsMode         string
-	EcsClientSubnet string
-	HonorClientCD   bool
+	RootServers        []RootServer
+	ValidateDNSSEC     string
+	QNameMinimize      bool
+	EDNSSize           uint16
+	Timeout            time.Duration
+	Retries            int
+	ProbeTopN          int
+	ProbeInterval      time.Duration
+	PreferIPv6         bool
+	MaxDepth           int
+	MaxCNAME           int
+	MaxReferrals       int
+	Socks5Proxy        string
+	Socks5Username     string
+	Socks5Password     string
+	SendThrough        net.IP
+	EcsMode            string
+	EcsClientSubnet    string
+	HonorClientCD      bool
+	Nsec3MaxIterations int
 
 	initOnce       sync.Once
 	clients        map[string]*dns.Client
@@ -375,6 +376,7 @@ func init() {
 				},
 			},
 			boolFiller("HonorClientCD", "honorClientCD", true),
+			intFiller("Nsec3MaxIterations", "nsec3MaxIterations", 0, 2500, 100),
 		},
 	}); err != nil {
 		common.ErrOutput(err)
@@ -407,6 +409,9 @@ func (r *Recursive) initialize() {
 	validator.resolveDS = r.fetchDS
 	validator.logger = func(msg string) {
 		common.ErrOutput(fmt.Errorf(msg))
+	}
+	if r.Nsec3MaxIterations > 0 {
+		validator.nsec3MaxIter = uint16(r.Nsec3MaxIterations)
 	}
 	r.validator = validator
 	// Initial probes are best-effort; failures keep default ordering.

--- a/internal/upstream/resolvers/recursive/validate.go
+++ b/internal/upstream/resolvers/recursive/validate.go
@@ -25,6 +25,7 @@ type dnssecValidator struct {
 	resolveDNSKEY func(name string) (*dns.Msg, error)
 	resolveDS     func(name string) (*dns.Msg, error)
 	logger        func(msg string)
+	nsec3MaxIter  uint16 // maximum accepted NSEC3 iteration count (RFC 9276)
 
 	keyCache map[string]*keyState
 	cacheMu  sync.Mutex
@@ -54,9 +55,10 @@ func newValidator() *dnssecValidator {
 		resolveDS: func(string) (*dns.Msg, error) {
 			return nil, errDNSSECNotImplemented
 		},
-		logger:   func(string) {},
-		keyCache: map[string]*keyState{},
-		metrics:  &validationMetrics{},
+		logger:       func(string) {},
+		nsec3MaxIter: 100,
+		keyCache:     map[string]*keyState{},
+		metrics:      &validationMetrics{},
 	}
 }
 
@@ -239,7 +241,7 @@ func (v *dnssecValidator) validateDenial(msg *dns.Msg, q dns.Question, bestEffor
 	if len(nsecRecords) > 0 {
 		covered = verifyNSECCoverage(qname, qtype, msg.Rcode, nsecRecords)
 	} else if len(nsec3Records) > 0 {
-		covered = verifyNSEC3Coverage(qname, qtype, msg.Rcode, nsec3Records)
+		covered = verifyNSEC3Coverage(qname, qtype, msg.Rcode, nsec3Records, v.nsec3MaxIter)
 	} else {
 		if bestEffort {
 			return false, false, nil
@@ -633,28 +635,49 @@ func verifyNSECCoverage(qname string, qtype uint16, rcode int, nsecs []*dns.NSEC
 		wildcard := normalizeName("*." + closest)
 		return nsecCoversName(wildcard, nsecs)
 	}
-	// NODATA: need proof that the name exists but the type does not.
+	// NODATA: an NSEC whose owner is EXACTLY qname with the qtype and CNAME bits clear.
+	// A covering (non-owner) NSEC proves the name does not exist, which is not a NODATA
+	// proof, so it is no longer accepted (RFC 4035 section 4.4.1).
 	for _, n := range nsecs {
-		owner := normalizeName(n.Hdr.Name)
-		if owner == qname && !typeInBitmap(n.TypeBitMap, qtype) {
-			return true
-		}
-		if covers := nsecNameCovered(owner, normalizeName(n.NextDomain), qname); covers && !typeInBitmap(n.TypeBitMap, qtype) {
+		if normalizeName(n.Hdr.Name) == qname && !typeInBitmap(n.TypeBitMap, qtype) && !typeInBitmap(n.TypeBitMap, dns.TypeCNAME) {
 			return true
 		}
 	}
 	return false
 }
 
-func verifyNSEC3Coverage(qname string, qtype uint16, rcode int, nsec3s []*dns.NSEC3) bool {
+// nsec3ParamsUsable gates an NSEC3 set before any hashing (RFC 5155 section 12.1.3,
+// RFC 9276): the hash must be SHA-1, the iteration count must not exceed maxIter, and
+// every record must share the same hash/iterations/salt. miekg's HashName returns ""
+// for an unknown hash, which would make Cover/Match match arbitrary names, and a large
+// iteration count is a CPU-exhaustion vector — so this must run before Cover/Match.
+func nsec3ParamsUsable(nsec3s []*dns.NSEC3, maxIter uint16) bool {
+	if len(nsec3s) == 0 {
+		return false
+	}
+	p := nsec3s[0]
+	if p.Hash != dns.SHA1 || p.Iterations > maxIter {
+		return false
+	}
+	for _, n := range nsec3s {
+		if n.Hash != p.Hash || n.Iterations != p.Iterations || !strings.EqualFold(n.Salt, p.Salt) {
+			return false
+		}
+	}
+	return true
+}
+
+func verifyNSEC3Coverage(qname string, qtype uint16, rcode int, nsec3s []*dns.NSEC3, maxIter uint16) bool {
 	qname = normalizeName(qname)
-	// Choose parameter set from first record.
+	if !nsec3ParamsUsable(nsec3s, maxIter) {
+		return false
+	}
 	params := nsec3s[0]
 	if rcode == dns.RcodeNameError {
-		// Proof 1: qname does not exist.
+		// Proof 1: qname does not exist (a covering NSEC3).
 		var hasNameProof bool
 		for _, n := range nsec3s {
-			if n.Hash == params.Hash && n.Iterations == params.Iterations && n.Salt == params.Salt && n.Cover(qname) {
+			if n.Cover(qname) {
 				hasNameProof = true
 				break
 			}
@@ -662,25 +685,24 @@ func verifyNSEC3Coverage(qname string, qtype uint16, rcode int, nsec3s []*dns.NS
 		if !hasNameProof {
 			return false
 		}
-		// Proof 2: wildcard does not exist for closest encloser.
+		// Proof 2: the wildcard at the closest encloser does not exist.
 		closest := closestEncloserNSEC3(qname, nsec3s, params)
 		if closest == "" {
 			return false
 		}
 		wildcard := normalizeName("*." + closest)
 		for _, n := range nsec3s {
-			if n.Hash == params.Hash && n.Iterations == params.Iterations && n.Salt == params.Salt && n.Cover(wildcard) {
+			if n.Cover(wildcard) {
 				return true
 			}
 		}
 		return false
 	}
-	// NODATA: qname exists but type missing -> either matched hash lacking type or covered by other interval.
+	// NODATA: an NSEC3 that MATCHES qname (exact owner-hash) with the qtype and CNAME
+	// bits clear. A covering (non-matching) record proves non-existence, not NODATA, so
+	// it is no longer accepted (RFC 5155 section 8.5 / RFC 4035 section 4.4.1).
 	for _, n := range nsec3s {
-		if n.Match(qname) && !typeInBitmap(n.TypeBitMap, qtype) {
-			return true
-		}
-		if n.Cover(qname) {
+		if n.Match(qname) && !typeInBitmap(n.TypeBitMap, qtype) && !typeInBitmap(n.TypeBitMap, dns.TypeCNAME) {
 			return true
 		}
 	}


### PR DESCRIPTION
Continues the DNSSEC denial-of-existence rework.

## Problems
- **NSEC3 CPU-DoS + unknown-hash (R2-04/R2-05):** `verifyNSEC3Coverage` called `Cover`/`Match` with an attacker-controlled iteration count and hash. miekg's `HashName` returns `""` for an unknown hash, which makes `Cover`/`Match` match arbitrary names, and a large iteration count is a hashing CPU-exhaustion vector.
- **NODATA accepted on a covering interval (SD-12):** both the NSEC and NSEC3 NODATA paths accepted a record that merely *covers* qname (which proves non-existence, not NODATA), and ignored a present CNAME (RFC 4035 §4.4.1).

## Fix
- `nsec3ParamsUsable` gates the set before any hashing: hash must be SHA-1, iterations ≤ `nsec3MaxIterations` (new config, default 100, RFC 9276), and all records share hash/iterations/salt.
- NSEC3 NODATA: require an NSEC3 that **Matches** qname with the qtype and CNAME bits clear; the bare `n.Cover(qname)` acceptance is removed.
- NSEC NODATA: require an NSEC whose owner is **exactly** qname (qtype + CNAME clear); the covering-interval acceptance is removed.

## Tests
`TestNSEC3ParamsUsable` (cap / unknown-hash / mixed params / empty); `TestVerifyNSECCoverageNODATAExactMatch` (covering rejected, exact accepted, CNAME/qtype rejected); `TestVerifyNSEC3CoverageNODATARequiresMatch` (match accepted, non-match rejected, over-cap gated).

## Verification
`go build/vet/test ./...` green; `go test -race ./...` clean. On real DNSSEC (lab, strict): `iana.org` positive and `iana.org MX` **NODATA** both validate to Secure+AD. (Authenticated NXDOMAIN is SERVFAILed by the pre-existing `closestEncloser` bug — confirmed identical on the prior build — and is fixed in the next PR of this series.)