### PR TITLE
fix(dnssec): NSEC NXDOMAIN closest-encloser derivation + canonical ordering (RFC 4035 §5.4 / 4034 §6.1)

### DIFF
--- a/internal/upstream/resolvers/recursive/denial_test.go
+++ b/internal/upstream/resolvers/recursive/denial_test.go
@@ -60,6 +60,55 @@ func TestVerifyNSECCoverageNODATAExactMatch(t *testing.T) {
 	}
 }
 
+func TestCanonicalLess(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"example.", "a.example.", true},      // ancestor sorts first
+		{"a.example.", "example.", false},     //
+		{"a.example.", "z.example.", true},    //
+		{"*.example.", "a.example.", true},    // '*' (0x2a) < 'a' (0x61)
+		{"a.example.", "a.example.", false},   // equal
+		{"a.z.example.", "b.example.", false}, // right-to-left: 'z' > 'b' (byte order would disagree)
+		{"b.example.", "a.z.example.", true},
+	}
+	for _, c := range cases {
+		if got := canonicalLess(c.a, c.b); got != c.want {
+			t.Errorf("canonicalLess(%q, %q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+func TestVerifyNSECCoverageNXDOMAIN(t *testing.T) {
+	nsec := func(owner, next string, types ...uint16) *dns.NSEC {
+		return &dns.NSEC{
+			Hdr:        dns.RR_Header{Name: owner, Rrtype: dns.TypeNSEC, Class: dns.ClassINET},
+			NextDomain: next,
+			TypeBitMap: types,
+		}
+	}
+	// Legitimate NXDOMAIN for nope.example.: covered by (a.example., z.example.), and
+	// the wildcard *.example. is covered by (example., a.example.) -> proof holds.
+	proof := []*dns.NSEC{
+		nsec("example.", "a.example.", dns.TypeSOA, dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC),
+		nsec("a.example.", "z.example.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+	}
+	if !verifyNSECCoverage("nope.example.", dns.TypeA, dns.RcodeNameError, proof) {
+		t.Fatalf("a legitimate NXDOMAIN proof should be accepted")
+	}
+	// R2-02 forgery: a wildcard *.example. EXISTS, so nope.example. should have been
+	// answered by the wildcard, not NXDOMAIN. The covering NSEC must not prove NXDOMAIN
+	// (the old closestEncloser collapsed to root and accepted this).
+	forge := []*dns.NSEC{
+		nsec("a.example.", "z.example.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC), // covers nope.example.
+		nsec("*.example.", "a.example.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC), // the wildcard exists
+	}
+	if verifyNSECCoverage("nope.example.", dns.TypeA, dns.RcodeNameError, forge) {
+		t.Fatalf("NXDOMAIN must be rejected when a wildcard at the closest encloser exists")
+	}
+}
+
 func TestVerifyNSEC3CoverageNODATARequiresMatch(t *testing.T) {
 	const salt = "aabbccdd"
 	hashedOwner := func(name string) string {

--- a/internal/upstream/resolvers/recursive/validate.go
+++ b/internal/upstream/resolvers/recursive/validate.go
@@ -626,13 +626,18 @@ func splitProofs(rrs []dns.RR) ([]*dns.NSEC, []*dns.NSEC3) {
 
 func verifyNSECCoverage(qname string, qtype uint16, rcode int, nsecs []*dns.NSEC) bool {
 	qname = normalizeName(qname)
-	// NXDOMAIN: need proof that name doesn't exist and that wildcard closest encloser doesn't exist.
+	// NXDOMAIN (RFC 4035 section 5.4): prove qname does not exist and that no wildcard
+	// at the closest encloser could have synthesized an answer. The closest encloser is
+	// derived from the NSEC that actually covers qname (the existing names immediately
+	// bracketing the non-existence gap), never inferred as the root — so a single
+	// covering NSEC plus an apex-wildcard NSEC can no longer "prove" NXDOMAIN for a
+	// wildcard-answerable name.
 	if rcode == dns.RcodeNameError {
-		if !nsecCoversName(qname, nsecs) {
+		ce, ok := nsecClosestEncloser(qname, nsecs)
+		if !ok || ce == qname {
 			return false
 		}
-		closest := closestEncloser(qname, nsecs)
-		wildcard := normalizeName("*." + closest)
+		wildcard := normalizeName("*." + ce)
 		return nsecCoversName(wildcard, nsecs)
 	}
 	// NODATA: an NSEC whose owner is EXACTLY qname with the qtype and CNAME bits clear.
@@ -720,28 +725,78 @@ func nsecCoversName(name string, nsecs []*dns.NSEC) bool {
 	return false
 }
 
-func nsecNameCovered(owner, next, name string) bool {
-	if owner == name {
-		return true
+// canonicalLess reports whether a sorts strictly before b in DNSSEC canonical name
+// order (RFC 4034 section 6.1): labels are compared from the rightmost (TLD) label
+// inward, each as a case-insensitive octet string; a shorter name (a proper ancestor)
+// sorts first. Plain Go string comparison is not equivalent for multi-label names.
+func canonicalLess(a, b string) bool {
+	al := dns.SplitDomainName(a)
+	bl := dns.SplitDomainName(b)
+	i, j := len(al)-1, len(bl)-1
+	for i >= 0 && j >= 0 {
+		ai := strings.ToLower(al[i])
+		bj := strings.ToLower(bl[j])
+		if ai != bj {
+			return ai < bj
+		}
+		i--
+		j--
 	}
-	if owner < next {
-		return owner < name && name < next
-	}
-	// Wrap-around interval.
-	return owner < name || name < next
+	return i < j // the name with fewer remaining labels sorts first
 }
 
-func closestEncloser(qname string, nsecs []*dns.NSEC) string {
-	labels := dns.SplitDomainName(qname)
-	for i := 0; i < len(labels); i++ {
-		candidate := normalizeName(strings.Join(labels[i:], "."))
-		for _, n := range nsecs {
-			if normalizeName(n.Hdr.Name) == candidate {
-				return candidate
-			}
-		}
+// nsecNameCovered reports whether name falls strictly inside the gap an NSEC proves
+// to be empty, i.e. owner < name < next in canonical order (with wrap-around for the
+// last NSEC). An endpoint (name == owner or name == next) exists and is not covered.
+func nsecNameCovered(owner, next, name string) bool {
+	if name == owner || name == next {
+		return false
 	}
-	return "."
+	if canonicalLess(owner, next) {
+		return canonicalLess(owner, name) && canonicalLess(name, next)
+	}
+	// Wrap-around: the last NSEC's next is the zone apex (<= owner canonically).
+	return canonicalLess(owner, name) || canonicalLess(name, next)
+}
+
+// longestCommonAncestor returns the deepest DNS name that is an ancestor (or self) of
+// both a and b, comparing labels from the right (RFC 4034 section 6.1).
+func longestCommonAncestor(a, b string) string {
+	al := dns.SplitDomainName(a)
+	bl := dns.SplitDomainName(b)
+	i, j := len(al)-1, len(bl)-1
+	var common []string
+	for i >= 0 && j >= 0 && strings.EqualFold(al[i], bl[j]) {
+		common = append([]string{al[i]}, common...)
+		i--
+		j--
+	}
+	if len(common) == 0 {
+		return "."
+	}
+	return normalizeName(strings.Join(common, "."))
+}
+
+// nsecClosestEncloser returns the closest encloser of qname proven by the NSEC chain.
+// It requires an NSEC covering qname (proving qname does not exist) and derives the
+// closest encloser as the deepest ancestor of qname that the covering NSEC shows to
+// exist — the longer of the common ancestors of qname with the covering NSEC's owner
+// and next names (RFC 4035 section 5.4).
+func nsecClosestEncloser(qname string, nsecs []*dns.NSEC) (string, bool) {
+	for _, n := range nsecs {
+		owner := normalizeName(n.Hdr.Name)
+		next := normalizeName(n.NextDomain)
+		if !nsecNameCovered(owner, next, qname) {
+			continue
+		}
+		a := longestCommonAncestor(qname, owner)
+		b := longestCommonAncestor(qname, next)
+		if dns.CountLabel(b) > dns.CountLabel(a) {
+			return b, true
+		}
+		return a, true
+	}
+	return "", false
 }
 
 func closestEncloserNSEC3(qname string, nsec3s []*dns.NSEC3, params *dns.NSEC3) string {


### PR DESCRIPTION
## Summary

Closes a denial-of-existence soundness bug in the recursive resolver's DNSSEC validator: the **NXDOMAIN** proof inferred the *closest encloser* by walking `qname`'s ancestors looking for an NSEC owner match. When no ancestor carried its own NSEC, that walk **collapsed to the root**, so the wildcard it then checked for non-existence was `*.` (root) rather than `*.<closest-encloser>`.

### Impact
An attacker positioned on-path (or a malicious authoritative) could pair **one covering NSEC** with an **apex-wildcard NSEC** and have the validator accept a forged **NXDOMAIN** for a name that the wildcard would legitimately answer — i.e. downgrade a wildcard-synthesized record to authenticated non-existence. Because the bug also rejected *legitimate* NXDOMAIN proofs in common topologies, strict-mode `NXDOMAIN` lookups were SERVFAILing in practice.

## Fix
- **`nsecClosestEncloser`** — derive the closest encloser from the NSEC that actually *covers* `qname`: it is the deeper of `LCA(qname, owner)` and `LCA(qname, next)`, both of which are names proven to exist. The wildcard tested for non-existence is then `*.<closest-encloser>`, so a wildcard that exists at the closest encloser correctly **defeats** the NXDOMAIN proof.
- **`canonicalLess` / `longestCommonAncestor`** — DNSSEC canonical name ordering (RFC 4034 §6.1): labels compared case-insensitively from the rightmost inward, shorter (ancestor) names first. Raw Go string comparison mis-ordered multi-label zones.
- **`nsecNameCovered`** — canonical, **endpoint-exclusive** interval test (an NSEC's `owner`/`next` are existing names, not covered), with wrap-around for the apex NSEC.
- Removes the old ancestor-walk `closestEncloser` helper.

## Tests
- `TestCanonicalLess` — canonical ordering incl. `*` (0x2a) `< a`, ancestor-first, right-to-left multi-label.
- `TestVerifyNSECCoverageNXDOMAIN` — legitimate proof accepted; the wildcard-exists forgery (covering NSEC + existing `*.example.` NSEC) rejected.
- Existing NODATA / NSEC3 denial tests unchanged and green.

## Verification
- `go test ./...` green; `go vet ./...` clean.
- `-race` green on the recursive package (Linux host).
- **End-to-end against live signed `iana.org`** (strict mode, recursive): a random `*.iana.org A` now returns **`NXDOMAIN` + `ad`** (previously SERVFAIL); positive (`iana.org A/MX`) returns NOERROR + `ad`; bogus (`dnssec-failed.org`) still SERVFAIL.

## Scope
Pure validator logic; no config/API surface change. No behavioral change to positive or NODATA paths.