### PR TITLE
fix(recursive): don't stall the resolver on a broken address family (IPv6 failover)

### DIFF
--- a/internal/upstream/resolvers/recursive/scoreboard_test.go
+++ b/internal/upstream/resolvers/recursive/scoreboard_test.go
@@ -1,0 +1,99 @@
+package recursive
+
+import (
+	"net"
+	"testing"
+	"time"
+)
+
+func hasV4(ips []net.IP) bool {
+	for _, ip := range ips {
+		if ip.To4() != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func hasV6(ips []net.IP) bool {
+	for _, ip := range ips {
+		if ip.To4() == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// TestScoreboardPrefersIPv4ByDefault: on a cold board with equal RTTs, IPv4 sorts
+// first so a host with broken IPv6 egress does not stall cold queries.
+func TestScoreboardPrefersIPv4ByDefault(t *testing.T) {
+	roots := []RootServer{
+		{Host: "a", Addresses: []net.IP{net.ParseIP("198.41.0.4"), net.ParseIP("2001:503:ba3e::2:30")}},
+		{Host: "b", Addresses: []net.IP{net.ParseIP("199.9.14.201"), net.ParseIP("2001:500:200::b")}},
+	}
+	sb := newScoreboard(roots, 5)
+	picked := sb.pickRoots(false)
+	if len(picked) == 0 || picked[0].To4() == nil {
+		t.Fatalf("expected an IPv4 root first by default, got %v", picked)
+	}
+	// Determinism: a second identical call returns the same order.
+	again := sb.pickRoots(false)
+	for i := range picked {
+		if !picked[i].Equal(again[i]) {
+			t.Fatalf("pickRoots is not deterministic: %v vs %v", picked, again)
+		}
+	}
+}
+
+// TestScoreboardPreferIPv6Honored: when preferIPv6 is set, IPv6 sorts first.
+func TestScoreboardPreferIPv6Honored(t *testing.T) {
+	roots := []RootServer{
+		{Host: "a", Addresses: []net.IP{net.ParseIP("198.41.0.4"), net.ParseIP("2001:503:ba3e::2:30")}},
+	}
+	sb := newScoreboard(roots, 5)
+	picked := sb.pickRoots(true)
+	if len(picked) == 0 || picked[0].To4() != nil {
+		t.Fatalf("expected an IPv6 root first when preferIPv6, got %v", picked)
+	}
+}
+
+// TestScoreboardFamilyDiversity: even when one family would fill the whole topN by
+// score, the selection still includes at least one server of the other family so a
+// dead family cannot starve the working one.
+func TestScoreboardFamilyDiversity(t *testing.T) {
+	roots := []RootServer{
+		{Addresses: []net.IP{net.ParseIP("198.41.0.4")}},
+		{Addresses: []net.IP{net.ParseIP("199.9.14.201")}},
+		{Addresses: []net.IP{net.ParseIP("192.33.4.12")}},
+		{Addresses: []net.IP{net.ParseIP("2001:500:2::c")}},
+	}
+	sb := newScoreboard(roots, 2) // topN smaller than the IPv4 count
+	picked := sb.pickRoots(false)
+	if len(picked) != 2 {
+		t.Fatalf("expected 2 picks, got %d (%v)", len(picked), picked)
+	}
+	if !hasV4(picked) || !hasV6(picked) {
+		t.Fatalf("expected both address families in the selection, got %v", picked)
+	}
+}
+
+// TestMarkSuccessRTTInMillis: a proven-fast server (low ms RTT) must outrank an untried
+// server. This guards the unit fix: raw-nanosecond RTTs would make tried servers score
+// in the millions and always lose to untried (often dead) ones.
+func TestMarkSuccessRTTInMillis(t *testing.T) {
+	fast := net.ParseIP("198.41.0.4")
+	untried := net.ParseIP("199.9.14.201")
+	sb := newScoreboard([]RootServer{{Addresses: []net.IP{fast, untried}}}, 5)
+	sb.markSuccess(fast, 10*time.Millisecond)
+	picked := sb.pickFrom([]net.IP{fast, untried}, false, 2)
+	if len(picked) != 2 || !picked[0].Equal(fast) {
+		t.Fatalf("expected the proven-fast server first, got %v", picked)
+	}
+	// A server that just failed must drop below an untried one.
+	sb.markFailure(fast)
+	sb.markFailure(fast)
+	picked = sb.pickFrom([]net.IP{fast, untried}, false, 2)
+	if !picked[0].Equal(untried) {
+		t.Fatalf("expected the untried server to outrank a just-failed one, got %v", picked)
+	}
+}

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -414,8 +414,12 @@ func (r *Recursive) initialize() {
 		validator.nsec3MaxIter = uint16(r.Nsec3MaxIterations)
 	}
 	r.validator = validator
-	// Initial probes are best-effort; failures keep default ordering.
-	r.scoreboard.probe(func(ip net.IP) (time.Duration, error) {
+	// Initial probes are best-effort and only refine root ordering; they MUST NOT block
+	// the first query. Running them on the request path would stall startup on a host
+	// with a broken address family (e.g. dead IPv6 egress) for the sum of every dead
+	// root's timeout. Run them in the background — queries use the optimistic default
+	// ordering (IPv4-first) until the scoreboard is refined.
+	go r.scoreboard.probe(func(ip net.IP) (time.Duration, error) {
 		msg := new(dns.Msg)
 		msg.SetQuestion(".", dns.TypeNS)
 		var best time.Duration
@@ -1019,10 +1023,18 @@ func (s *nsScoreboard) markSuccess(ip net.IP, rtt time.Duration) {
 		s.scores[key] = entry
 	}
 	const alpha = 0.3
+	// Store the EWMA in milliseconds. The optimistic seed used for untried servers
+	// (scoreValue) is also in milliseconds, so a proven-fast server outranks an untried
+	// one. Storing raw nanoseconds here would make every tried server score in the
+	// millions and thus always lose to untried (often dead) servers.
+	ms := float64(rtt) / float64(time.Millisecond)
+	if ms <= 0 {
+		ms = 0.1 // sub-millisecond RTT floor
+	}
 	if entry.ewmaRTT == 0 {
-		entry.ewmaRTT = float64(rtt)
+		entry.ewmaRTT = ms
 	} else {
-		entry.ewmaRTT = alpha*float64(rtt) + (1-alpha)*entry.ewmaRTT
+		entry.ewmaRTT = alpha*ms + (1-alpha)*entry.ewmaRTT
 	}
 	entry.failStreak = 0
 	entry.successes++
@@ -1057,20 +1069,25 @@ func (s *nsScoreboard) register(ips []net.IP) {
 	}
 }
 
+// probe measures every root concurrently. Probing all roots sequentially would, on a
+// host with a broken address family, block for the sum of every dead server's timeout;
+// running them in parallel bounds the wall time to the slowest single probe. The caller
+// should still run probe off the request path (see initialize).
 func (s *nsScoreboard) probe(exchange func(ip net.IP) (time.Duration, error)) {
+	var wg sync.WaitGroup
 	for _, ip := range s.roots {
-		var best time.Duration
-		var err error
-		best, err = exchange(ip)
-		if err != nil {
-			best = 0
-		}
-		if best > 0 {
+		wg.Add(1)
+		go func(ip net.IP) {
+			defer wg.Done()
+			best, err := exchange(ip)
+			if err != nil || best <= 0 {
+				s.markFailure(ip)
+				return
+			}
 			s.markSuccess(ip, best)
-		} else {
-			s.markFailure(ip)
-		}
+		}(ip)
 	}
+	wg.Wait()
 }
 
 // pickRoots returns the top ranked root IPs.
@@ -1092,12 +1109,16 @@ func (s *nsScoreboard) pickFrom(ips []net.IP, preferIPv6 bool, limit int) []net.
 		seen[key] = true
 		entry := s.scores[key]
 		if entry == nil {
-			entry = &nsScore{ip: ip, ewmaRTT: 50} // optimistic seed
+			entry = &nsScore{ip: ip} // untried; scoreValue applies the optimistic seed
 		}
 		list = append(list, entry)
 	}
 	sort.Slice(list, func(i, j int) bool {
-		return scoreValue(list[i], preferIPv6) < scoreValue(list[j], preferIPv6)
+		si, sj := scoreValue(list[i], preferIPv6), scoreValue(list[j], preferIPv6)
+		if si != sj {
+			return si < sj
+		}
+		return list[i].ip.String() < list[j].ip.String() // deterministic tiebreak
 	})
 	if limit <= 0 || limit > len(list) {
 		limit = len(list)
@@ -1106,19 +1127,64 @@ func (s *nsScoreboard) pickFrom(ips []net.IP, preferIPv6 bool, limit int) []net.
 	for i := 0; i < limit; i++ {
 		out = append(out, list[i].ip)
 	}
-	return out
+	return ensureFamilyDiversity(out, list, limit)
 }
 
+// ensureFamilyDiversity guarantees that, whenever both address families are present in
+// the candidate set, the returned selection contains at least one server of each. On a
+// host where one family's egress is broken, the working family must always be attempted
+// rather than starved by a full-of-the-dead-family selection. If the selection is
+// single-family, the worst slot is replaced by the best-scored server of the missing
+// family (the candidate list is already sorted best-first).
+func ensureFamilyDiversity(out []net.IP, sorted []*nsScore, limit int) []net.IP {
+	if limit < 2 || len(out) < 2 {
+		return out
+	}
+	haveV4, haveV6 := false, false
+	for _, ip := range out {
+		if ip.To4() != nil {
+			haveV4 = true
+		} else {
+			haveV6 = true
+		}
+	}
+	if haveV4 && haveV6 {
+		return out
+	}
+	missingIsV6 := !haveV6 // selection is all-IPv4 -> we need an IPv6, and vice versa
+	for _, sc := range sorted {
+		if (sc.ip.To4() == nil) == missingIsV6 {
+			out[len(out)-1] = sc.ip
+			return out
+		}
+	}
+	return out // the missing family is not available at all
+}
+
+// familyBiasMillis is the small RTT-equivalent margin (in ms) that biases server
+// selection toward the preferred address family (IPv4 by default). It is intentionally
+// small so a genuinely faster opposite-family server still wins, but it breaks
+// cold-start ties deterministically so a host with broken IPv6 egress does not stall on
+// dead IPv6 servers.
+const familyBiasMillis = 15.0
+
+// scoreValue ranks a nameserver; lower is better. Score = EWMA RTT (ms) + a steep
+// per-consecutive-failure penalty (a server that just failed drops far down) + the
+// address-family bias.
 func scoreValue(entry *nsScore, preferIPv6 bool) float64 {
 	base := entry.ewmaRTT
-	if base == 0 {
-		base = 50 // seed default
+	if base <= 0 {
+		base = 50 // optimistic seed (ms) for an untried server
 	}
-	penalty := float64(entry.failStreak * 100)
-	if preferIPv6 && entry.ip.To4() == nil {
-		return base + penalty - 5
+	score := base + float64(entry.failStreak)*100
+	if entry.ip.To4() == nil { // IPv6
+		if preferIPv6 {
+			score -= familyBiasMillis
+		} else {
+			score += familyBiasMillis
+		}
 	}
-	return base + penalty
+	return score
 }
 
 func durationFiller(field, jsonKey string, def time.Duration) descriptor.ObjectFiller {


### PR DESCRIPTION
## Summary

On a host with a broken address family — most commonly **dead IPv6 egress** — the recursive resolver could hang for the full timeout budget, and the *first* query after startup frequently timed out entirely. Three compounding causes, fixed here:

### 1. Synchronous startup probe blocked the first query
The root probe ran **synchronously inside `initOnce.Do`** on the first `Resolve`, sequentially probing all 26 root addresses. The 13 dead IPv6 roots each blocked for the full retry budget (~tens of seconds total) before resolution even began. The probe is best-effort and only refines ordering, so it now runs **in the background** and probes roots **concurrently** (`sync.WaitGroup`).

### 2. Equal family scoring + unstable sort → all-IPv6 top-N
`scoreValue` scored IPv4 and IPv6 equally by default, and `sort.Slice` is not stable, so a cold scoreboard could select an all-IPv6 top-N that fails on a broken-IPv6 host (flaky: worked once, failed the next time). Selection is now biased toward the preferred family (**IPv4 by default**) by a small RTT-equivalent margin (`familyBiasMillis`), with a deterministic IP tiebreak. A genuinely faster opposite-family server still wins because the margin is small relative to real RTT differences. `PreferIPv6: true` is honored symmetrically.

### 3. RTT unit bug defeated learning
`ewmaRTT` stored raw **nanoseconds** while the optimistic seed was `50`, so every *tried* server scored in the millions and always lost to *untried* (often dead) servers — the scoreboard never learned to avoid them. The EWMA is now stored in **milliseconds**, so a proven-fast server outranks an untried one, and a just-failed server drops below untried.

### Robustness backstop: `ensureFamilyDiversity`
Whenever both families are present in the candidate set, the selection always includes **at least one server of each**, so a dead family can never starve the working one regardless of scoring quirks.

## Verification
- `go test ./...` green; `go vet ./...` clean; **`-race` clean** on the recursive package (the new background/concurrent probe).
- **Host-verified on a host with a dead IPv6 tunnel (HE 6in4, 100% loss):** signed (`iana.org` A/MX, `cloudflare.com`) validate with **AD**, unsigned (`google.com`, `microsoft.com`) resolve — all **sub-second**, where master's binary **timed out** (15s) on the first query.
- New tests: `scoreboard_test.go` — IPv4-default preference, `PreferIPv6` honored, family diversity, RTT-unit ranking, failed-server demotion.

## Scope
Recursive server selection / startup only. No config surface change (the existing `preferIPv6` / `probeTopN` knobs are unchanged in meaning). No DNSSEC behavior change.