### PR TITLE
fix(dnssec): exclude SOA RRSIG from denial proofs — strict negative validation SERVFAILed all signed zones

### DIFF
--- a/internal/upstream/resolvers/recursive/validate.go
+++ b/internal/upstream/resolvers/recursive/validate.go
@@ -599,12 +599,22 @@ func extractRRSet(msg *dns.Msg, rrType uint16, name string) ([]dns.RR, []*dns.RR
 	return rrs, sigs
 }
 
+// collectProofRecords returns the NSEC/NSEC3 records from an authority section and
+// only the RRSIGs that cover them. The RRSIG over the SOA (always present in an
+// NXDOMAIN/NODATA authority for negative caching) must be excluded: it has no covered
+// record in this set, so feeding it to validateSection would leave an orphan signature
+// that fails strict verification and SERVFAILs every signed negative answer. The SOA's
+// own signature is validated separately against the full authority section.
 func collectProofRecords(nsecSection []dns.RR) []dns.RR {
 	var out []dns.RR
 	for _, rr := range nsecSection {
-		switch rr.(type) {
-		case *dns.NSEC, *dns.NSEC3, *dns.RRSIG:
+		switch v := rr.(type) {
+		case *dns.NSEC, *dns.NSEC3:
 			out = append(out, rr)
+		case *dns.RRSIG:
+			if v.TypeCovered == dns.TypeNSEC || v.TypeCovered == dns.TypeNSEC3 {
+				out = append(out, rr)
+			}
 		}
 	}
 	return out

--- a/internal/upstream/resolvers/recursive/validate_test.go
+++ b/internal/upstream/resolvers/recursive/validate_test.go
@@ -202,6 +202,50 @@ func mustGenerateKey(name string) (*dns.DNSKEY, crypto.Signer) {
 	return key, signer
 }
 
+// TestValidateDenialWithSOARRSIG guards against a regression where the RRSIG covering
+// the SOA in an NXDOMAIN/NODATA authority section (always present for negative caching)
+// was collected as a denial proof record, leaving an orphan signature that failed
+// strict verification and SERVFAILed every signed negative answer. Real responses
+// always carry SOA + RRSIG(SOA); earlier tests omitted them and missed the bug.
+func TestValidateDenialWithSOARRSIG(t *testing.T) {
+	now := time.Now()
+	key, priv := mustGenerateKey("example.")
+	secureState := func() *dnssecValidator {
+		v := newValidator()
+		v.now = func() time.Time { return now }
+		v.keyCache["example."] = &keyState{keys: []*dns.DNSKEY{key}, secure: true, expires: now.Add(time.Hour)}
+		return v
+	}
+	soa := &dns.SOA{Hdr: dns.RR_Header{Name: "example.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300}, Ns: "ns.example.", Mbox: "h.example.", Serial: 1, Refresh: 7200, Retry: 3600, Expire: 1209600, Minttl: 300}
+	soaSig := mustSign([]dns.RR{soa}, key, priv, "example.", dns.TypeSOA, now)
+
+	t.Run("NXDOMAIN", func(t *testing.T) {
+		cover := &dns.NSEC{Hdr: dns.RR_Header{Name: "a.example.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300}, NextDomain: "z.example.", TypeBitMap: []uint16{dns.TypeA}}
+		coverSig := mustSign([]dns.RR{cover}, key, priv, "example.", dns.TypeNSEC, now)
+		apex := &dns.NSEC{Hdr: dns.RR_Header{Name: "example.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300}, NextDomain: "a.example.", TypeBitMap: []uint16{dns.TypeSOA, dns.TypeNS}}
+		apexSig := mustSign([]dns.RR{apex}, key, priv, "example.", dns.TypeNSEC, now)
+		msg := &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeNameError}}
+		msg.Ns = []dns.RR{soa, soaSig, cover, coverSig, apex, apexSig}
+		q := dns.Question{Name: "nope.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+		proof, _, err := secureState().validateDenial(msg, q, false)
+		if err != nil || !proof {
+			t.Fatalf("NXDOMAIN with SOA+RRSIG must validate: proof=%v err=%v", proof, err)
+		}
+	})
+
+	t.Run("NODATA", func(t *testing.T) {
+		nodata := &dns.NSEC{Hdr: dns.RR_Header{Name: "www.example.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300}, NextDomain: "x.example.", TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC}}
+		nodataSig := mustSign([]dns.RR{nodata}, key, priv, "example.", dns.TypeNSEC, now)
+		msg := &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}}
+		msg.Ns = []dns.RR{soa, soaSig, nodata, nodataSig}
+		q := dns.Question{Name: "www.example.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}
+		proof, _, err := secureState().validateDenial(msg, q, false)
+		if err != nil || !proof {
+			t.Fatalf("NODATA with SOA+RRSIG must validate: proof=%v err=%v", proof, err)
+		}
+	})
+}
+
 func mustSign(rrs []dns.RR, key *dns.DNSKEY, priv crypto.Signer, signer string, covered uint16, now time.Time) *dns.RRSIG {
 	sig := &dns.RRSIG{
 		Hdr: dns.RR_Header{


### PR DESCRIPTION
## Summary

**Critical correctness fix.** In strict mode, the validator **SERVFAILed every signed negative answer** (NXDOMAIN and NODATA) from real zones — e.g. `nonexistent.iana.org` returned SERVFAIL instead of an authenticated `NXDOMAIN`.

### Root cause
`collectProofRecords` gathered **every** RRSIG in the authority section, including the **RRSIG covering the SOA** that every NXDOMAIN/NODATA response carries for negative-cache TTL. `validateDenial` then passed that signature to `validateSection`, but the SOA record itself is *not* a denial proof record, so the RRSIG had **no covered RRset** in the proof set. Strict `verifyRRSetWithKeys` cannot verify a signature with no records and returns an error → the whole negative answer SERVFAILed.

This was masked because the existing denial unit tests constructed `msg.Ns` **without** the SOA and its RRSIG; real authoritative responses always include them.

### Fix
Collect only the RRSIGs whose `TypeCovered` is `NSEC` or `NSEC3`. The SOA's own signature continues to be validated against the full authority section in `validateMessage` (unchanged).

```go
case *dns.RRSIG:
    if v.TypeCovered == dns.TypeNSEC || v.TypeCovered == dns.TypeNSEC3 {
        out = append(out, rr)
    }
```

## Verification
- `go test ./...` green; `go vet ./...` clean; `-race` clean (recursive package).
- New regression test `TestValidateDenialWithSOARRSIG` (NXDOMAIN **and** NODATA, each carrying `SOA + RRSIG(SOA)`) — fails without the fix, passes with it.
- **Host-verified against live signed zones** (strict, recursive):
  - `iana.org` (NSEC3) `nonexistent.* A` → **NXDOMAIN + AD** (was SERVFAIL)
  - `iana.org` A/MX → NOERROR + AD; `dnssec-failed.org` → SERVFAIL (bogus); unsigned `google.com` and its NXDOMAIN → resolve without AD.

## Scope
One function (`collectProofRecords`); no config/API change. Affects only which records are handed to negative-proof validation.