### PR TITLE
fix(dnssec): require authenticated DS-absence proof before treating a delegation as insecure (RFC 4035 §5.2)

### DIFF
--- a/internal/upstream/resolvers/recursive/denial_test.go
+++ b/internal/upstream/resolvers/recursive/denial_test.go
@@ -109,6 +109,100 @@ func TestVerifyNSECCoverageNXDOMAIN(t *testing.T) {
 	}
 }
 
+func TestNSECProvesNoDS(t *testing.T) {
+	nsec := func(owner string, types ...uint16) *dns.NSEC {
+		return &dns.NSEC{
+			Hdr:        dns.RR_Header{Name: owner, Rrtype: dns.TypeNSEC, Class: dns.ClassINET},
+			NextDomain: "zzz.",
+			TypeBitMap: types,
+		}
+	}
+	// Valid: owner == delegation point, NS set, DS and SOA clear.
+	good := nsec("example.", dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC)
+	if !nsecProvesNoDS("example.", []*dns.NSEC{good}) {
+		t.Fatalf("NS-only delegation NSEC should prove no DS")
+	}
+	// DS present -> a DS exists, not a no-DS proof.
+	withDS := nsec("example.", dns.TypeNS, dns.TypeDS, dns.TypeRRSIG)
+	if nsecProvesNoDS("example.", []*dns.NSEC{withDS}) {
+		t.Fatalf("an NSEC with the DS bit set must not prove no DS")
+	}
+	// SOA present -> this is the child apex NSEC, not a parent-side proof (RFC 6840 4.3).
+	withSOA := nsec("example.", dns.TypeNS, dns.TypeSOA, dns.TypeRRSIG)
+	if nsecProvesNoDS("example.", []*dns.NSEC{withSOA}) {
+		t.Fatalf("a child-apex NSEC (SOA bit set) must not prove no DS")
+	}
+	// No NS -> not a delegation.
+	noNS := nsec("example.", dns.TypeA, dns.TypeRRSIG)
+	if nsecProvesNoDS("example.", []*dns.NSEC{noNS}) {
+		t.Fatalf("an NSEC without the NS bit must not prove a delegation no-DS")
+	}
+	// Wrong owner -> proves nothing about example.
+	other := nsec("other.", dns.TypeNS, dns.TypeRRSIG)
+	if nsecProvesNoDS("example.", []*dns.NSEC{other}) {
+		t.Fatalf("an NSEC owned by a different name must not prove no DS for example.")
+	}
+}
+
+func TestNextCloserName(t *testing.T) {
+	cases := []struct{ qname, ce, want string }{
+		{"sub.example.", "example.", "sub.example."},
+		{"a.b.example.", "example.", "b.example."},
+		{"a.b.c.example.", "c.example.", "b.c.example."},
+		{"example.", "example.", ""}, // ce not a proper ancestor
+		{"example.", "other.", ""},   // ce longer/unrelated
+	}
+	for _, c := range cases {
+		if got := nextCloserName(c.qname, c.ce); got != c.want {
+			t.Errorf("nextCloserName(%q,%q)=%q want %q", c.qname, c.ce, got, c.want)
+		}
+	}
+}
+
+func TestNSEC3ProvesNoDS(t *testing.T) {
+	const salt = "aabbccdd"
+	ho := func(n string) string { return dns.HashName(n, dns.SHA1, 0, salt) + ".example." }
+	mk := func(owner string, flags uint8, next string, types ...uint16) *dns.NSEC3 {
+		return &dns.NSEC3{
+			Hdr:        dns.RR_Header{Name: owner, Rrtype: dns.TypeNSEC3, Class: dns.ClassINET},
+			Hash:       dns.SHA1,
+			Flags:      flags,
+			Iterations: 0,
+			Salt:       salt,
+			NextDomain: next,
+			TypeBitMap: types,
+		}
+	}
+	// Direct NODATA: NSEC3 matching the delegation, NS set, DS and SOA clear.
+	nodata := mk(ho("sub.example."), 0, "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV", dns.TypeNS, dns.TypeRRSIG)
+	if !nodata.Match("sub.example.") {
+		t.Skipf("test setup: NSEC3.Match did not hold")
+	}
+	if !nsec3ProvesNoDS("sub.example.", []*dns.NSEC3{nodata}, 100) {
+		t.Fatalf("a matching NS-only NSEC3 should prove no DS")
+	}
+	// DS bit set at the match -> a DS exists.
+	withDS := mk(ho("sub.example."), 0, "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV", dns.TypeNS, dns.TypeDS)
+	if nsec3ProvesNoDS("sub.example.", []*dns.NSEC3{withDS}, 100) {
+		t.Fatalf("a matching NSEC3 with the DS bit must not prove no DS")
+	}
+	// Opt-out: closest encloser matches (example. apex) and an opt-out NSEC3 covers the
+	// next closer name (sub.example.).
+	ceMatch := mk(ho("example."), 0, "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV", dns.TypeNS, dns.TypeSOA, dns.TypeDNSKEY)
+	optout := mk("00000000000000000000000000000000.example.", 0x01, "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV", dns.TypeNS)
+	if !ceMatch.Match("example.") || !optout.Cover("sub.example.") {
+		t.Skipf("test setup: opt-out match/cover assumptions did not hold")
+	}
+	if !nsec3ProvesNoDS("sub.example.", []*dns.NSEC3{ceMatch, optout}, 100) {
+		t.Fatalf("opt-out span should prove an insecure (no-DS) delegation")
+	}
+	// Same span but the opt-out flag is clear -> not an opt-out proof.
+	noOpt := mk("00000000000000000000000000000000.example.", 0x00, "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV", dns.TypeNS)
+	if nsec3ProvesNoDS("sub.example.", []*dns.NSEC3{ceMatch, noOpt}, 100) {
+		t.Fatalf("a covering NSEC3 without the opt-out flag must not prove no DS")
+	}
+}
+
 func TestVerifyNSEC3CoverageNODATARequiresMatch(t *testing.T) {
 	const salt = "aabbccdd"
 	hashedOwner := func(name string) string {

--- a/internal/upstream/resolvers/recursive/validate.go
+++ b/internal/upstream/resolvers/recursive/validate.go
@@ -313,6 +313,17 @@ func (v *dnssecValidator) trustedKeys(zone string) (*keyState, error) {
 	dsSet, dsSigs := extractRRSet(dsMsg, dns.TypeDS, zone)
 	dsExpiry := rrsetExpiry(dsSet, dsSigs, v.now())
 	if len(dsSet) == 0 {
+		// No DS RRset. Declaring the child Insecure (unsigned) is only sound if the
+		// parent authentically proves that no DS exists at the delegation point;
+		// otherwise an on-path attacker who strips the DS RRset (and its NSEC/NSEC3
+		// proof) would downgrade a secure child to unsigned and have forged data
+		// accepted (RFC 4035 section 5.2, RFC 6840 section 5). If the parent is itself
+		// insecure, insecurity is inherited and no proof is required.
+		if parentState != nil && parentState.secure && len(parentState.keys) > 0 {
+			if !v.proveNoDS(zone, dsMsg, parentState.keys) {
+				return nil, fmt.Errorf("dnssec: no authenticated DS-absence proof for %s (possible downgrade)", zone)
+			}
+		}
 		state := &keyState{secure: false, keys: nil, expires: fallbackExpiry(v.now())}
 		if !dsExpiry.IsZero() && dsExpiry.Before(state.expires) {
 			state.expires = dsExpiry
@@ -820,6 +831,125 @@ func closestEncloserNSEC3(qname string, nsec3s []*dns.NSEC3, params *dns.NSEC3) 
 		}
 	}
 	return ""
+}
+
+// proveNoDS reports whether dsMsg authentically proves that zone has no DS RRset,
+// using NSEC/NSEC3 records signed by the parent (parentKeys). A secure parent must
+// supply this proof before a child may be treated as an insecure (unsigned)
+// delegation; without it, stripping the DS RRset would downgrade a secure child
+// (RFC 4035 section 5.2, RFC 6840 section 5).
+func (v *dnssecValidator) proveNoDS(zone string, dsMsg *dns.Msg, parentKeys []*dns.DNSKEY) bool {
+	if dsMsg == nil {
+		return false
+	}
+	nsecs, nsec3s := validatedDenialRecords(dsMsg.Ns, parentKeys)
+	if nsecProvesNoDS(zone, nsecs) {
+		return true
+	}
+	return nsec3ProvesNoDS(zone, nsec3s, v.nsec3MaxIter)
+}
+
+// validatedDenialRecords returns the NSEC and NSEC3 records from section whose RRSIGs
+// verify against keys (signer in bailiwick). Unsigned or unverifiable records are
+// dropped so that only parent-authenticated proofs are considered.
+func validatedDenialRecords(section []dns.RR, keys []*dns.DNSKEY) ([]*dns.NSEC, []*dns.NSEC3) {
+	var nsecs []*dns.NSEC
+	var nsec3s []*dns.NSEC3
+	for _, set := range groupRRsets(section) {
+		if len(set.rrs) == 0 {
+			continue
+		}
+		switch set.rrs[0].(type) {
+		case *dns.NSEC, *dns.NSEC3:
+		default:
+			continue
+		}
+		if ok, _ := verifyRRSetWithKeys(set.rrs, set.sigs, keys, true); !ok {
+			continue
+		}
+		for _, rr := range set.rrs {
+			switch r := rr.(type) {
+			case *dns.NSEC:
+				nsecs = append(nsecs, r)
+			case *dns.NSEC3:
+				nsec3s = append(nsec3s, r)
+			}
+		}
+	}
+	return nsecs, nsec3s
+}
+
+// nsecProvesNoDS reports whether an NSEC owned by zone proves there is no DS RRset:
+// the DS bit must be clear, the SOA bit must be clear (so the child zone's own apex
+// NSEC cannot be replayed as a parent-side no-DS proof, RFC 6840 section 4.3), and the
+// NS bit must be set (the owner is a delegation point). Matches Unbound's
+// val_nsec_proves_no_ds semantics.
+func nsecProvesNoDS(zone string, nsecs []*dns.NSEC) bool {
+	zone = normalizeName(zone)
+	for _, n := range nsecs {
+		if normalizeName(n.Hdr.Name) != zone {
+			continue
+		}
+		if typeInBitmap(n.TypeBitMap, dns.TypeDS) || typeInBitmap(n.TypeBitMap, dns.TypeSOA) {
+			continue
+		}
+		if !typeInBitmap(n.TypeBitMap, dns.TypeNS) {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// nsec3ProvesNoDS reports whether an NSEC3 set proves there is no DS RRset at zone,
+// either directly (an NSEC3 matching zone with NS set, SOA and DS clear) or via an
+// opt-out span (a matching NSEC3 for the closest encloser and an opt-out NSEC3 covering
+// the next closer name, RFC 5155 section 6 / section 7.2.4).
+func nsec3ProvesNoDS(zone string, nsec3s []*dns.NSEC3, maxIter uint16) bool {
+	if len(nsec3s) == 0 || !nsec3ParamsUsable(nsec3s, maxIter) {
+		return false
+	}
+	zone = normalizeName(zone)
+	params := nsec3s[0]
+	// Direct NODATA: an NSEC3 matching zone, DS and SOA clear, NS set.
+	for _, n := range nsec3s {
+		if !n.Match(zone) {
+			continue
+		}
+		if typeInBitmap(n.TypeBitMap, dns.TypeDS) || typeInBitmap(n.TypeBitMap, dns.TypeSOA) {
+			return false
+		}
+		return typeInBitmap(n.TypeBitMap, dns.TypeNS)
+	}
+	// Opt-out: the closest encloser exists and the next closer name is covered by an
+	// NSEC3 whose opt-out flag is set.
+	ce := closestEncloserNSEC3(zone, nsec3s, params)
+	if ce == "" || ce == zone {
+		return false
+	}
+	nextCloser := nextCloserName(zone, ce)
+	if nextCloser == "" {
+		return false
+	}
+	for _, n := range nsec3s {
+		if n.Cover(nextCloser) && n.Flags&0x01 == 1 {
+			return true
+		}
+	}
+	return false
+}
+
+// nextCloserName returns the name one label longer than ce on the path from ce to
+// qname (the "next closer name", RFC 5155 section 1.3). It returns "" if ce is not a
+// proper ancestor of qname.
+func nextCloserName(qname, ce string) string {
+	qLabels := dns.SplitDomainName(normalizeName(qname))
+	ceLabels := dns.SplitDomainName(normalizeName(ce))
+	if len(ceLabels) >= len(qLabels) {
+		return ""
+	}
+	idx := len(qLabels) - len(ceLabels) - 1
+	return normalizeName(strings.Join(qLabels[idx:], "."))
 }
 
 func typeInBitmap(types []uint16, qtype uint16) bool {

--- a/internal/upstream/resolvers/recursive/validate_test.go
+++ b/internal/upstream/resolvers/recursive/validate_test.go
@@ -152,20 +152,22 @@ func TestValidatorNSECNXDOMAIN(t *testing.T) {
 func TestValidatorInsecureDelegation(t *testing.T) {
 	now := time.Now()
 	rootKey, rootPriv := mustGenerateKey(".")
-	childKey, childPriv := mustGenerateKey("example.")
+
+	// The (secure) root proves there is no DS for example. with an NSEC owned by the
+	// delegation point: NS set, SOA and DS clear. This authenticates the insecure
+	// delegation (RFC 4035 section 5.2).
+	noDS := &dns.NSEC{Hdr: dns.RR_Header{Name: "example.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 600}, NextDomain: "zzz.", TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC}}
+	noDSSig := mustSign([]dns.RR{noDS}, rootKey, rootPriv, ".", dns.TypeNSEC, now)
 	rootDNSKEYSig := mustSign([]dns.RR{rootKey}, rootKey, rootPriv, ".", dns.TypeDNSKEY, now)
-	dnskeySig := mustSign([]dns.RR{childKey}, childKey, childPriv, "example.", dns.TypeDNSKEY, now)
 
 	v := newValidator()
 	v.trustAnchors = []dns.RR{rootKey}
 	v.now = func() time.Time { return now }
-	v.resolveDS = func(string) (*dns.Msg, error) { return &dns.Msg{}, nil }
+	v.resolveDS = func(string) (*dns.Msg, error) { return &dns.Msg{Ns: []dns.RR{noDS, noDSSig}}, nil }
 	v.resolveDNSKEY = func(name string) (*dns.Msg, error) {
 		switch dns.Fqdn(name) {
 		case ".":
 			return &dns.Msg{Answer: []dns.RR{rootKey, rootDNSKEYSig}}, nil
-		case "example.":
-			return &dns.Msg{Answer: []dns.RR{childKey, dnskeySig}}, nil
 		default:
 			return &dns.Msg{}, nil
 		}
@@ -177,10 +179,46 @@ func TestValidatorInsecureDelegation(t *testing.T) {
 
 	validated, err := v.validateResponse(msg, q, "strict", true)
 	if err != nil {
-		t.Fatalf("unexpected error for insecure delegation: %v", err)
+		t.Fatalf("unexpected error for authenticated insecure delegation: %v", err)
 	}
 	if validated {
 		t.Fatalf("insecure delegation should not be marked validated")
+	}
+}
+
+// TestValidatorDSStripDowngrade verifies that a missing DS RRset under a SECURE parent
+// with no authenticated DS-absence proof (an on-path DS-stripping downgrade) is
+// rejected rather than silently treated as an insecure (unsigned) delegation.
+func TestValidatorDSStripDowngrade(t *testing.T) {
+	now := time.Now()
+	rootKey, rootPriv := mustGenerateKey(".")
+	rootDNSKEYSig := mustSign([]dns.RR{rootKey}, rootKey, rootPriv, ".", dns.TypeDNSKEY, now)
+
+	v := newValidator()
+	v.trustAnchors = []dns.RR{rootKey}
+	v.now = func() time.Time { return now }
+	// DS RRset and its proof both stripped: empty response.
+	v.resolveDS = func(string) (*dns.Msg, error) { return &dns.Msg{}, nil }
+	v.resolveDNSKEY = func(name string) (*dns.Msg, error) {
+		switch dns.Fqdn(name) {
+		case ".":
+			return &dns.Msg{Answer: []dns.RR{rootKey, rootDNSKEYSig}}, nil
+		default:
+			return &dns.Msg{}, nil
+		}
+	}
+
+	if _, err := v.trustedKeys("example."); err == nil {
+		t.Fatalf("expected trustedKeys to reject a stripped DS with no DS-absence proof")
+	}
+
+	// A forged unsigned answer for the downgraded zone must SERVFAIL in strict, not be
+	// served as insecure.
+	msg := &dns.Msg{MsgHdr: dns.MsgHdr{Rcode: dns.RcodeSuccess}}
+	msg.Answer = []dns.RR{&dns.A{Hdr: dns.RR_Header{Name: "www.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300}, A: net.IP{6, 6, 6, 6}}}
+	q := dns.Question{Name: "www.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	if validated, err := v.validateResponse(msg, q, "strict", true); err == nil || validated {
+		t.Fatalf("strict must reject a DS-stripping downgrade: validated=%v err=%v", validated, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes a **downgrade vulnerability** in the chain of trust. `trustedKeys` treated *any* DS query that returned no DS RRset as an insecure (unsigned) delegation. An on-path attacker (or malicious authoritative) who **strips the DS RRset and its NSEC/NSEC3 proof** could thereby downgrade a secure child to "unsigned" and have forged, unsigned data accepted instead of SERVFAIL.

## Fix
When the DS RRset is absent **and the parent is secure**, require an authenticated proof from the parent that no DS exists at the delegation point before treating the child as insecure:

- **NSEC** — an NSEC owned by the delegation point with **NS set** and **DS + SOA clear** (SOA-clear rejects a replayed child-apex NSEC, RFC 6840 §4.3). Matches Unbound's `val_nsec_proves_no_ds`.
- **NSEC3** — a matching NSEC3 (NS set, DS + SOA clear) **or** an opt-out span: a matching closest-encloser NSEC3 plus an opt-out NSEC3 covering the next closer name (RFC 5155 §6 / §7.2.4).

All proof records must verify against the parent's DNSKEYs (signer in bailiwick) via `validatedDenialRecords`. If the parent is itself insecure, insecurity is inherited and no proof is required. Absent a valid proof under a secure parent, `trustedKeys` now errors → **SERVFAIL in strict (fail closed)**; permissive degrades to served-without-AD per its best-effort contract.

New helpers: `proveNoDS`, `validatedDenialRecords`, `nsecProvesNoDS`, `nsec3ProvesNoDS`, `nextCloserName`.

## Tests
- `TestNSECProvesNoDS`, `TestNSEC3ProvesNoDS` (direct NODATA **and** opt-out span, plus rejections: DS present, SOA set, no NS, wrong owner, opt-out flag clear), `TestNextCloserName`.
- `TestValidatorDSStripDowngrade` — stripped DS under a secure parent is rejected (errors / SERVFAIL), not served as insecure.
- `TestValidatorInsecureDelegation` updated to supply a real root-signed no-DS proof (the legitimate insecure path).

## Verification
- `go test ./...` green; `go vet ./...` clean; `-race` clean.
- **Host-verified (strict, recursive, live):** unsigned-under-signed delegations still resolve — `google.com` / `microsoft.com` / `amazon.com` (.com opt-out NSEC3), `wikipedia.org` (.org) all NOERROR without AD; signed (`iana.org`, `cloudflare.com`, `example.net`) validate with AD; `iana.org` NXDOMAIN → NXDOMAIN+AD; `dnssec-failed.org` → SERVFAIL. proveNoDS accepts real opt-out proofs and does not regress insecure delegations.

## Scope
Validator trust-chain only; no config/API change. Depends on (and is built atop) the negative-validation SOA-RRSIG fix (#26) and the address-family failover fix (#25).