### PR TITLE
fix(dnssec): enforce NSEC3 NXDOMAIN next-closer constraint (RFC 5155 §8.3)

### DIFF
--- a/internal/upstream/resolvers/recursive/denial_test.go
+++ b/internal/upstream/resolvers/recursive/denial_test.go
@@ -1,10 +1,68 @@
 package recursive
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/miekg/dns"
 )
+
+// bumpHash returns the next base32hex string after h (with carry), so that (h, bumpHash(h))
+// is an empty span — a record with NextDomain == bumpHash(owner) covers nothing.
+func bumpHash(h string) string {
+	const b32 = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
+	b := []byte(h)
+	for i := len(b) - 1; i >= 0; i-- {
+		idx := strings.IndexByte(b32, b[i])
+		if idx >= 0 && idx < 31 {
+			b[i] = b32[idx+1]
+			return string(b)
+		}
+		b[i] = '0' // carry into the next position
+	}
+	return string(b)
+}
+
+func TestVerifyNSEC3CoverageNXDOMAIN(t *testing.T) {
+	const salt = "aabbccdd"
+	ceHash := dns.HashName("example.", dns.SHA1, 0, salt)
+	// ceMatch matches example. (the closest encloser) and, with NextDomain == its own
+	// owner hash, covers nothing — so it cannot stand in for the next-closer/wildcard
+	// covers on its own.
+	ceMatch := &dns.NSEC3{
+		Hdr:        dns.RR_Header{Name: ceHash + ".example.", Rrtype: dns.TypeNSEC3, Class: dns.ClassINET},
+		Hash:       dns.SHA1,
+		Iterations: 0,
+		Salt:       salt,
+		NextDomain: bumpHash(ceHash),
+		TypeBitMap: []uint16{dns.TypeSOA, dns.TypeNS, dns.TypeDNSKEY},
+	}
+	// cover spans the whole hash space, so it covers any next-closer name and any wildcard.
+	cover := &dns.NSEC3{
+		Hdr:        dns.RR_Header{Name: "00000000000000000000000000000000.example.", Rrtype: dns.TypeNSEC3, Class: dns.ClassINET},
+		Hash:       dns.SHA1,
+		Iterations: 0,
+		Salt:       salt,
+		NextDomain: "VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV",
+	}
+	if !ceMatch.Match("example.") || ceMatch.Cover("sub.example.") || !cover.Cover("sub.example.") {
+		t.Skipf("test setup: NSEC3 match/cover assumptions did not hold")
+	}
+	// Valid: closest encloser matches example., the next closer name (sub.example.) is
+	// covered, and *.example. is covered.
+	if !verifyNSEC3Coverage("sub.example.", dns.TypeA, dns.RcodeNameError, []*dns.NSEC3{ceMatch, cover}, 100) {
+		t.Fatalf("a valid NSEC3 NXDOMAIN proof should validate")
+	}
+	// Reject: a bare covering NSEC3 with no matching closest encloser is not a proof.
+	if verifyNSEC3Coverage("sub.example.", dns.TypeA, dns.RcodeNameError, []*dns.NSEC3{cover}, 100) {
+		t.Fatalf("a covering NSEC3 without a closest-encloser match must not prove NXDOMAIN")
+	}
+	// Reject: a closest-encloser match with nothing covering the next closer name (RFC
+	// 5155 section 8.3) is not a proof.
+	if verifyNSEC3Coverage("sub.example.", dns.TypeA, dns.RcodeNameError, []*dns.NSEC3{ceMatch}, 100) {
+		t.Fatalf("a closest-encloser match with no next-closer cover must not prove NXDOMAIN")
+	}
+}
 
 func TestNSEC3ParamsUsable(t *testing.T) {
 	mk := func(hash uint8, iter uint16, salt string) *dns.NSEC3 {

--- a/internal/upstream/resolvers/recursive/validate.go
+++ b/internal/upstream/resolvers/recursive/validate.go
@@ -700,29 +700,23 @@ func verifyNSEC3Coverage(qname string, qtype uint16, rcode int, nsec3s []*dns.NS
 	}
 	params := nsec3s[0]
 	if rcode == dns.RcodeNameError {
-		// Proof 1: qname does not exist (a covering NSEC3).
-		var hasNameProof bool
-		for _, n := range nsec3s {
-			if n.Cover(qname) {
-				hasNameProof = true
-				break
-			}
-		}
-		if !hasNameProof {
+		// RFC 5155 section 8.3: prove (a) the closest encloser exists — a matching
+		// NSEC3; (b) the next closer name (one label below the closest encloser toward
+		// qname) does not exist — a covering NSEC3; and (c) no wildcard at the closest
+		// encloser exists — a covering NSEC3 for *.<closest encloser>. Requiring the
+		// next closer name specifically, rather than any NSEC3 that merely covers qname,
+		// stops a covering NSEC3 for a deep qname from standing in for the missing
+		// closest-encloser / next-closer proof.
+		ce := closestEncloserNSEC3(qname, nsec3s, params)
+		if ce == "" || ce == qname {
 			return false
 		}
-		// Proof 2: the wildcard at the closest encloser does not exist.
-		closest := closestEncloserNSEC3(qname, nsec3s, params)
-		if closest == "" {
+		nextCloser := nextCloserName(qname, ce)
+		if nextCloser == "" || !nsec3SetCovers(nsec3s, nextCloser) {
 			return false
 		}
-		wildcard := normalizeName("*." + closest)
-		for _, n := range nsec3s {
-			if n.Cover(wildcard) {
-				return true
-			}
-		}
-		return false
+		wildcard := normalizeName("*." + ce)
+		return nsec3SetCovers(nsec3s, wildcard)
 	}
 	// NODATA: an NSEC3 that MATCHES qname (exact owner-hash) with the qtype and CNAME
 	// bits clear. A covering (non-matching) record proves non-existence, not NODATA, so
@@ -818,6 +812,17 @@ func nsecClosestEncloser(qname string, nsecs []*dns.NSEC) (string, bool) {
 		return a, true
 	}
 	return "", false
+}
+
+// nsec3SetCovers reports whether any NSEC3 in the set covers name (its hash falls
+// strictly within the record's [owner, next) span).
+func nsec3SetCovers(nsec3s []*dns.NSEC3, name string) bool {
+	for _, n := range nsec3s {
+		if n.Cover(name) {
+			return true
+		}
+	}
+	return false
 }
 
 func closestEncloserNSEC3(qname string, nsec3s []*dns.NSEC3, params *dns.NSEC3) string {


### PR DESCRIPTION
## Summary

Tightens the NSEC3 NXDOMAIN proof to the full RFC 5155 §8.3 three-record form. Previously the validator accepted any NSEC3 that merely **covered qname** as the name-non-existence proof. §8.3 requires proving the **next closer name** — the name one label below the closest encloser, toward qname — does not exist, not just qname itself. For a qname several labels below its closest encloser, a covering NSEC3 for the deep qname could stand in for the missing closest-encloser / next-closer proof.

## Fix
Derive the closest encloser (the longest ancestor of qname with a **matching** NSEC3), then require:
1. a covering NSEC3 for the **next closer name** (`nextCloserName(qname, ce)`), and
2. a covering NSEC3 for `*.<closest encloser>` (no wildcard synthesis).

Reuses `nextCloserName` (added with the DS-downgrade fix) and the new `nsec3SetCovers` helper.

## Tests
`TestVerifyNSEC3CoverageNXDOMAIN`:
- valid proof (closest-encloser match + next-closer cover + wildcard cover) validates;
- a bare covering NSEC3 with **no** closest-encloser match is rejected;
- a closest-encloser match with **no** next-closer cover is rejected.

## Verification
- `go test ./...` green; `go vet ./...` clean; `-race` clean.
- **Host-verified (strict, recursive, live):** `iana.org` (NSEC3) `nonexistent.* A` still returns **NXDOMAIN + AD**; positive/NODATA/bogus/unsigned paths unchanged.

## Scope
NSEC3 negative-proof logic only; no config/API change. Builds on the DS-downgrade (#27) and SOA-RRSIG (#26) fixes.