### PR TITLE
fix(cache): stop deleting refreshed entries via stale heap items; bound stale-refresh goroutines

### DIFF
--- a/internal/upstream/resolvers/cache/refresh_cleanup_test.go
+++ b/internal/upstream/resolvers/cache/refresh_cleanup_test.go
@@ -1,0 +1,124 @@
+package cache
+
+import (
+	"container/heap"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/zhouchenh/go-descriptor"
+)
+
+// TestCleanupExpiredSkipsStaleHeapDuplicate guards the data-loss bug where a re-cache
+// (refresh/prefetch) pushes a fresh heap item without removing the prior one, so a
+// still-fresh entry could be deleted by cleanupExpired via the leftover stale item when
+// ServeStale is off.
+func TestCleanupExpiredSkipsStaleHeapDuplicate(t *testing.T) {
+	c := &Cache{ServeStale: false}
+	c.entries = make(map[string]*Entry)
+	c.lru = NewLRUList()
+
+	past := time.Now().Add(-time.Minute)
+	future := time.Now().Add(time.Hour)
+
+	// A refreshed entry: its current expiry is in the future, but a stale heap item
+	// from a superseded (shorter) TTL still references it with a past expiry.
+	fresh := &Entry{ExpiresAt: future, lruNode: c.lru.AddToFront("fresh")}
+	c.entries["fresh"] = fresh
+	heap.Push(&c.queue, expirationItem{key: "fresh", expiresAt: past})
+
+	// A genuinely expired entry: the popped item's expiry matches the entry's expiry.
+	dead := &Entry{ExpiresAt: past, lruNode: c.lru.AddToFront("dead")}
+	c.entries["dead"] = dead
+	heap.Push(&c.queue, expirationItem{key: "dead", expiresAt: past})
+
+	c.cleanupExpired()
+
+	if _, ok := c.entries["fresh"]; !ok {
+		t.Fatalf("refreshed entry was wrongly deleted by a stale heap duplicate")
+	}
+	if _, ok := c.entries["dead"]; ok {
+		t.Fatalf("genuinely expired entry should have been deleted")
+	}
+}
+
+// gateResolver blocks inside Resolve until released, so a test can hold a refresh
+// in flight and observe whether a second refresh is (incorrectly) started.
+type gateResolver struct {
+	mu      sync.Mutex
+	calls   int
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (g *gateResolver) Type() descriptor.Type { return descriptor.TypeOfNew(new(*gateResolver)) }
+func (g *gateResolver) TypeName() string      { return "gate" }
+func (g *gateResolver) NameServerResolver()   {}
+
+func (g *gateResolver) Resolve(query *dns.Msg, depth int) (*dns.Msg, error) {
+	g.mu.Lock()
+	g.calls++
+	g.mu.Unlock()
+	g.entered <- struct{}{}
+	<-g.release
+	resp := new(dns.Msg)
+	resp.SetReply(query)
+	resp.Answer = append(resp.Answer, &dns.A{
+		Hdr: dns.RR_Header{Name: query.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+		A:   net.IP{1, 2, 3, 4},
+	})
+	return resp, nil
+}
+
+// TestTriggerRefreshBoundsToOnePerEntry verifies that serving stale for a hot name does
+// not spawn a refresh goroutine per request: while one refresh is in flight, further
+// triggerRefresh calls for the same entry are no-ops (gated by the prefetching CAS).
+func TestTriggerRefreshBoundsToOnePerEntry(t *testing.T) {
+	g := &gateResolver{entered: make(chan struct{}, 8), release: make(chan struct{})}
+	c := &Cache{Resolver: g, MaxEntries: 16, CleanupInterval: time.Hour}
+	c.initOnce.Do(c.init)
+	defer c.Stop()
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.org.", dns.TypeA)
+	entry := &Entry{ExpiresAt: time.Now().Add(time.Hour)}
+
+	// First refresh claims the flag and enters the (blocked) resolver.
+	c.triggerRefresh("k", entry, q, 5)
+	select {
+	case <-g.entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first refresh did not start")
+	}
+
+	// Several more refreshes while the first is in flight must all be no-ops.
+	for i := 0; i < 5; i++ {
+		c.triggerRefresh("k", entry, q, 5)
+	}
+	select {
+	case <-g.entered:
+		t.Fatal("a second refresh started while one was already in flight")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	close(g.release) // unblock the in-flight refresh
+
+	// Wait for the flag to reset (refresh completed) without a fixed sleep race.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadUint32(&entry.prefetching) != 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("prefetching flag was not reset after refresh completed")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	g.mu.Lock()
+	calls := g.calls
+	g.mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("expected exactly 1 upstream refresh call, got %d", calls)
+	}
+}

--- a/internal/upstream/resolvers/cache/types.go
+++ b/internal/upstream/resolvers/cache/types.go
@@ -222,7 +222,7 @@ func (c *Cache) Resolve(query *dns.Msg, depth int) (*dns.Msg, error) {
 		// Set the query ID to match the incoming query
 		response.Id = query.Id
 		if stale {
-			go c.triggerRefresh(key, query.Copy(), depth-1)
+			c.triggerRefresh(key, entry, query, depth-1)
 		} else {
 			c.maybePrefetch(key, entry, query.Copy(), depth-1)
 		}
@@ -391,13 +391,23 @@ func (c *Cache) fetchAndStore(query *dns.Msg, depth int, key string) (*dns.Msg, 
 	return resp, nil
 }
 
-func (c *Cache) triggerRefresh(key string, query *dns.Msg, depth int) {
-	if query == nil {
+// triggerRefresh asynchronously refreshes a stale entry. It bounds fan-out to at most
+// one in-flight refresh per entry by claiming the entry's prefetching flag (shared with
+// maybePrefetch and reset on re-cache and on completion), so serving stale for a hot
+// name no longer spawns a goroutine per request. The caller must not have already
+// wrapped this in its own goroutine — triggerRefresh starts exactly one.
+func (c *Cache) triggerRefresh(key string, entry *Entry, query *dns.Msg, depth int) {
+	if query == nil || entry == nil {
 		return
 	}
+	if !atomic.CompareAndSwapUint32(&entry.prefetching, 0, 1) {
+		return
+	}
+	queryCopy := query.Copy()
 	go func() {
+		defer atomic.StoreUint32(&entry.prefetching, 0)
 		_, _, _ = c.requests.Do(key, func() (interface{}, error) {
-			return c.fetchAndStore(query, depth, key)
+			return c.fetchAndStore(queryCopy, depth, key)
 		})
 	}()
 }
@@ -814,6 +824,16 @@ func (c *Cache) cleanupExpired() {
 			heap.Pop(&c.queue)
 			entry, ok := c.entries[item.key]
 			if !ok {
+				continue
+			}
+			// A re-cache (refresh/prefetch) pushes a fresh heap item without removing
+			// the prior one, so a key can have several heap items with divergent
+			// expiry. Only the item whose expiresAt matches the entry's current
+			// ExpiresAt reflects the live expiry; any other popped item is a stale
+			// duplicate from a superseded TTL and must NOT delete the (now-fresh)
+			// entry — otherwise a refreshed entry is evicted prematurely whenever
+			// ServeStale is off.
+			if !entry.ExpiresAt.Equal(item.expiresAt) {
 				continue
 			}
 			if c.ServeStale && time.Since(entry.ExpiresAt) <= c.StaleDuration {


### PR DESCRIPTION
Two related cache-resolver defects found while auditing the cache for performance work.

## 1. Data loss: a refreshed entry can be deleted by a stale heap item
`setWithDirectives` pushes a new `expirationItem` on **every** set *and* every update without removing the prior one, so a key accumulates heap items with divergent expiry. `cleanupExpired` keyed its delete on `item.key` only — so when it popped a **stale duplicate** (old expiry) for an entry that had since been refreshed to a *later* expiry, it deleted the **still-fresh** entry. This happened whenever `ServeStale` is off (the `ServeStale` branch coincidentally dodged it via `time.Since(entry.ExpiresAt)`).

**Fix:** cleanup now skips any popped item whose `expiresAt` does not equal the entry's current `ExpiresAt`, acting only on the item that reflects the live expiry. (A full heap-dedup via `heapIndex`/`heap.Fix` is a planned follow-up; this guard is correct and safe even with duplicates present.)

## 2. Unbounded goroutines while serving stale
A stale hit ran `go c.triggerRefresh(...)` and `triggerRefresh` itself spawned a **second** `go func(){ requests.Do(...) }()` — two goroutines per stale request. `singleflight` dedups the upstream *fetch* but not goroutine *creation*, so a hot stale name under load spawned a goroutine per query, each blocking on the shared in-flight result.

**Fix:** `triggerRefresh` now starts a **single** goroutine, gated by the entry's `prefetching` CAS (the same flag `maybePrefetch` uses, reset on re-cache and on completion), capping in-flight refresh at one per entry. Self-heals on completion/failure.

## Tests / verification
- `TestCleanupExpiredSkipsStaleHeapDuplicate` — a refreshed entry survives a stale duplicate; a genuinely expired entry is still removed.
- `TestTriggerRefreshBoundsToOnePerEntry` — exactly one upstream refresh while one is in flight; the flag resets afterward.
- Full cache suite green; **`-race` clean** on the host.

## Scope
Cache resolver only; no config/API change. Pure correctness + resource-bounding (no behavior change for non-stale hits or single-shot keys).