### PR TITLE
perf(cache): bound the expiration heap by rebuilding from live entries

### DIFF
--- a/internal/upstream/resolvers/cache/heap_bound_test.go
+++ b/internal/upstream/resolvers/cache/heap_bound_test.go
@@ -1,0 +1,44 @@
+package cache
+
+import (
+	"testing"
+	"time"
+)
+
+// TestExpirationHeapStaysBounded verifies that repeatedly re-caching keys does not grow
+// the expiration heap without bound. Each re-cache pushes a fresh heap item without
+// removing the prior one; pushExpiration rebuilds the heap once it exceeds ~2x the live
+// entry count, so the heap stays bounded regardless of update frequency.
+func TestExpirationHeapStaysBounded(t *testing.T) {
+	mock := &mockResolver{response: aResponse("x.example.")}
+	c := &Cache{Resolver: mock, MaxEntries: 1000, CleanupInterval: time.Hour}
+	c.initOnce.Do(c.init)
+	defer c.Stop()
+
+	resp := aResponse("k.example.")
+
+	// One key, updated many times: without bounding, the heap would hold ~2000 items.
+	for i := 0; i < 2000; i++ {
+		c.set("k", resp)
+	}
+	c.mutex.RLock()
+	ql, el := c.queue.Len(), len(c.entries)
+	c.mutex.RUnlock()
+	if ql > 2*el+16 {
+		t.Fatalf("single-key heap not bounded: queue=%d entries=%d", ql, el)
+	}
+
+	// Many distinct keys, each updated several times: heap stays within the bound of the
+	// live entry count.
+	for round := 0; round < 4; round++ {
+		for i := 0; i < 300; i++ {
+			c.set(string(rune('a'+i%26))+"-"+time.Duration(i).String(), resp)
+		}
+	}
+	c.mutex.RLock()
+	ql, el = c.queue.Len(), len(c.entries)
+	c.mutex.RUnlock()
+	if ql > 2*el+16 {
+		t.Fatalf("multi-key heap not bounded: queue=%d entries=%d", ql, el)
+	}
+}

--- a/internal/upstream/resolvers/cache/types.go
+++ b/internal/upstream/resolvers/cache/types.go
@@ -362,7 +362,7 @@ func (c *Cache) setWithDirectives(key string, response *dns.Msg, directives cach
 		existing.DisablePrefetch = directives.disablePrefetch
 		existing.DisableStale = directives.disableStale
 		c.lru.MoveToFront(existing.lruNode)
-		heap.Push(&c.queue, expirationItem{key: key, expiresAt: existing.ExpiresAt})
+		c.pushExpiration(key, existing.ExpiresAt)
 		return
 	}
 
@@ -386,7 +386,33 @@ func (c *Cache) setWithDirectives(key string, response *dns.Msg, directives cach
 	entry.ExpiresAt = entry.CachedAt.Add(time.Duration(entry.OriginalTTL) * time.Second)
 
 	c.entries[key] = entry
-	heap.Push(&c.queue, expirationItem{key: key, expiresAt: entry.ExpiresAt})
+	c.pushExpiration(key, entry.ExpiresAt)
+}
+
+// pushExpiration adds an expiration item and keeps the expiration heap bounded. A
+// re-cache (refresh/prefetch) pushes a fresh item without removing the prior one, so
+// duplicate items accumulate for frequently-updated keys. cleanupExpired discards stale
+// duplicates lazily (it only acts on the item whose expiry matches the live entry), but
+// the heap itself can still bloat between cleanups. When it grows past ~2x the live
+// entry count, rebuild it from the live entries — one item each — reclaiming the
+// duplicates. This is amortized O(1) per insert and bounds the heap at ~2*len(entries).
+// Callers must hold c.mutex.
+func (c *Cache) pushExpiration(key string, expiresAt time.Time) {
+	heap.Push(&c.queue, expirationItem{key: key, expiresAt: expiresAt})
+	if len(c.queue) > 2*len(c.entries)+16 {
+		c.rebuildExpirationQueueLocked()
+	}
+}
+
+// rebuildExpirationQueueLocked replaces the expiration heap with exactly one item per
+// live entry. Callers must hold c.mutex.
+func (c *Cache) rebuildExpirationQueueLocked() {
+	q := make(expirationHeap, 0, len(c.entries))
+	for k, e := range c.entries {
+		q = append(q, expirationItem{key: k, expiresAt: e.ExpiresAt})
+	}
+	c.queue = q
+	heap.Init(&c.queue)
 }
 
 func (c *Cache) fetchAndStore(query *dns.Msg, depth int, key string) (*dns.Msg, error) {


### PR DESCRIPTION
## Summary

`setWithDirectives` pushes a fresh `expirationItem` on **every** set *and* every update without removing the prior one, so the expiration heap accumulates duplicate items for frequently-refreshed keys. The earlier fix (#30) made `cleanupExpired` discard stale duplicates **lazily** (it acts only on the item whose expiry matches the live entry) — that fixed the correctness bug, but the heap itself can still bloat between cleanup passes.

This routes both pushes through `pushExpiration`, which **rebuilds the heap from the live entries** (one item each) once it grows past `~2*len(entries)`. Amortized O(1) per insert; the heap is now bounded at `~2*len(entries)` instead of growing with update frequency.

I chose the rebuild approach over a per-entry `heapIndex` + `heap.Fix`/`heap.Remove` refactor because the latter interacts awkwardly with the serve-stale path (an entry popped but kept for stale serving would lose its heap slot), and the rebuild is materially lower-risk for the same memory-boundedness guarantee.

## Tests / verification
- `TestExpirationHeapStaysBounded` — 2000 updates to a single key, and repeated updates across many keys, both keep the heap within `2*entries+16`.
- Full cache suite green; **`-race` clean** on the host.

## Scope
Cache resolver only; no config/API change; no behavior change to lookups, eviction, or cleanup correctness.