### PR TITLE
perf(nameserver): reuse TCP/DoT connections from a bounded idle pool

### DIFF
--- a/internal/upstream/resolvers/nameserver/pool.go
+++ b/internal/upstream/resolvers/nameserver/pool.go
@@ -1,0 +1,72 @@
+package nameserver
+
+import (
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+const (
+	// defaultMaxIdleConns bounds the idle connections (and file descriptors) a single
+	// pool may hold. Each nameServer client dials exactly one destination, so this is a
+	// per-destination cap.
+	defaultMaxIdleConns = 8
+	// defaultConnIdleTimeout is how long an idle pooled connection may be reused before
+	// it is assumed the peer has likely closed it; older idle connections are closed
+	// rather than reused. A reuse that nonetheless hits a peer-closed connection falls
+	// back to a fresh dial, so this only trades off re-dial frequency.
+	defaultConnIdleTimeout = 10 * time.Second
+)
+
+type pooledConn struct {
+	conn      *dns.Conn
+	idleSince time.Time
+}
+
+// connPool is a small bounded pool of idle stream (TCP / DoT) connections to a single
+// destination, reused one outstanding query at a time. It is safe for concurrent use.
+type connPool struct {
+	mu          sync.Mutex
+	idle        []*pooledConn
+	maxIdle     int
+	idleTimeout time.Duration
+}
+
+func newConnPool() *connPool {
+	return &connPool{maxIdle: defaultMaxIdleConns, idleTimeout: defaultConnIdleTimeout}
+}
+
+// get returns a reusable idle connection, or nil if none is available. Idle
+// connections older than idleTimeout are closed and skipped so a likely-dead peer
+// connection is not handed out.
+func (p *connPool) get() *dns.Conn {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for len(p.idle) > 0 {
+		n := len(p.idle) - 1
+		pc := p.idle[n]
+		p.idle[n] = nil
+		p.idle = p.idle[:n]
+		if time.Since(pc.idleSince) > p.idleTimeout {
+			pc.conn.Close()
+			continue
+		}
+		return pc.conn
+	}
+	return nil
+}
+
+// put returns a connection to the pool for reuse. If the pool is already at maxIdle the
+// connection is closed instead, so the idle-connection (and file-descriptor) count
+// stays bounded.
+func (p *connPool) put(conn *dns.Conn) {
+	p.mu.Lock()
+	if len(p.idle) >= p.maxIdle {
+		p.mu.Unlock()
+		conn.Close()
+		return
+	}
+	p.idle = append(p.idle, &pooledConn{conn: conn, idleSince: time.Now()})
+	p.mu.Unlock()
+}

--- a/internal/upstream/resolvers/nameserver/pool_test.go
+++ b/internal/upstream/resolvers/nameserver/pool_test.go
@@ -1,0 +1,118 @@
+package nameserver
+
+import (
+	"net"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// fakeConn is a no-op net.Conn that records how many times it was closed.
+type fakeConn struct{ closed int32 }
+
+func (f *fakeConn) Read([]byte) (int, error)         { return 0, nil }
+func (f *fakeConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (f *fakeConn) Close() error                     { atomic.AddInt32(&f.closed, 1); return nil }
+func (f *fakeConn) LocalAddr() net.Addr              { return nil }
+func (f *fakeConn) RemoteAddr() net.Addr             { return nil }
+func (f *fakeConn) SetDeadline(time.Time) error      { return nil }
+func (f *fakeConn) SetReadDeadline(time.Time) error  { return nil }
+func (f *fakeConn) SetWriteDeadline(time.Time) error { return nil }
+
+func TestConnPoolBoundsIdle(t *testing.T) {
+	p := newConnPool()
+	p.maxIdle = 2
+	conns := []*fakeConn{{}, {}, {}}
+	for _, fc := range conns {
+		p.put(&dns.Conn{Conn: fc})
+	}
+	if atomic.LoadInt32(&conns[2].closed) != 1 {
+		t.Fatalf("surplus connection beyond maxIdle should be closed on put, closed=%d", conns[2].closed)
+	}
+	if len(p.idle) != 2 {
+		t.Fatalf("pool should hold exactly maxIdle=2 idle conns, got %d", len(p.idle))
+	}
+	if p.get() == nil || p.get() == nil {
+		t.Fatal("get should return the two pooled connections")
+	}
+	if p.get() != nil {
+		t.Fatal("get on an empty pool should return nil")
+	}
+}
+
+func TestConnPoolIdleTimeout(t *testing.T) {
+	p := newConnPool()
+	p.idleTimeout = 10 * time.Millisecond
+	fc := &fakeConn{}
+	p.put(&dns.Conn{Conn: fc})
+	time.Sleep(25 * time.Millisecond)
+	if p.get() != nil {
+		t.Fatal("an idle connection older than idleTimeout must not be reused")
+	}
+	if atomic.LoadInt32(&fc.closed) != 1 {
+		t.Fatalf("an expired idle connection must be closed, closed=%d", fc.closed)
+	}
+}
+
+type countingListener struct {
+	net.Listener
+	accepts int32
+}
+
+func (l *countingListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err == nil {
+		atomic.AddInt32(&l.accepts, 1)
+	}
+	return c, err
+}
+
+// TestNameServerTCPConnectionReuse verifies that sequential queries over TCP reuse a
+// single pooled connection instead of dialing (and handshaking) per query.
+func TestNameServerTCPConnectionReuse(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	cl := &countingListener{Listener: ln}
+	handler := dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Answer = append(m.Answer, &dns.A{
+			Hdr: dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.IP{1, 2, 3, 4},
+		})
+		_ = w.WriteMsg(m)
+	})
+	srv := &dns.Server{Listener: cl, Handler: handler}
+	go func() { _ = srv.ActivateAndServe() }()
+	defer srv.Shutdown()
+
+	host, portStr, _ := net.SplitHostPort(ln.Addr().String())
+	port, _ := strconv.Atoi(portStr)
+	ns := &NameServer{
+		Address:      net.ParseIP(host),
+		Port:         uint16(port),
+		Protocol:     "tcp",
+		QueryTimeout: 2 * time.Second,
+	}
+
+	const N = 12
+	for i := 0; i < N; i++ {
+		q := new(dns.Msg)
+		q.SetQuestion("example.com.", dns.TypeA)
+		resp, err := ns.Resolve(q, 5)
+		if err != nil {
+			t.Fatalf("query %d failed: %v", i, err)
+		}
+		if len(resp.Answer) != 1 {
+			t.Fatalf("query %d: expected 1 answer, got %d", i, len(resp.Answer))
+		}
+	}
+	if got := atomic.LoadInt32(&cl.accepts); got > 2 {
+		t.Fatalf("expected connection reuse (<=2 accepts) for %d sequential TCP queries, got %d", N, got)
+	}
+}

--- a/internal/upstream/resolvers/nameserver/types.go
+++ b/internal/upstream/resolvers/nameserver/types.go
@@ -38,6 +38,7 @@ type client struct {
 	dialFunc     func(network, address string) (conn net.Conn, err error)
 	dialTLSFunc  func(network, address string) (conn net.Conn, err error)
 	socks5Client *socks5.Client
+	pool         *connPool // idle connection reuse for stream (TCP/DoT) protocols
 	*dns.Client
 }
 
@@ -111,20 +112,62 @@ func (ns *NameServer) queryWithProtocol(query *dns.Msg, address string, protocol
 		clientToUse = ns.createClientForProtocol(protocol)
 	}
 
+	// Stream protocols (TCP and DoT) reuse idle connections from a bounded pool to
+	// avoid a TCP — and for DoT, a TLS — handshake on every query. UDP is
+	// connectionless and dials fresh each time as before.
+	if strings.HasPrefix(protocol, "tcp") && clientToUse.pool != nil {
+		return ns.streamExchange(clientToUse, address, query)
+	}
+
 	connection, err := clientToUse.Dial(address)
 	if err != nil {
 		return nil, err
 	}
 	defer connection.Close()
-	_ = connection.SetDeadline(time.Now().Add(ns.QueryTimeout))
+	return ns.exchangeOnConn(connection, query)
+}
+
+// streamExchange performs a query over a stream (TCP/DoT) connection, reusing a pooled
+// idle connection when available and returning it to the pool only after a clean
+// exchange. A pooled connection that fails (the peer closed it while idle) is discarded
+// and the query retried once on a fresh dial. Reuse is safe because each query carries a
+// fresh random transaction ID and exchangeOnConn discards any non-matching (stale)
+// response from a prior query on the connection before accepting an answer.
+func (ns *NameServer) streamExchange(c *client, address string, query *dns.Msg) (*dns.Msg, error) {
+	if conn := c.pool.get(); conn != nil {
+		msg, err := ns.exchangeOnConn(conn, query)
+		if err == nil {
+			c.pool.put(conn)
+			return msg, nil
+		}
+		conn.Close()
+	}
+	conn, err := c.Dial(address)
+	if err != nil {
+		return nil, err
+	}
+	msg, err := ns.exchangeOnConn(conn, query)
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+	c.pool.put(conn)
+	return msg, nil
+}
+
+// exchangeOnConn writes the query and reads until a response matching the query
+// (transaction ID + question) arrives or the deadline fires, discarding unsolicited or
+// mismatched messages so a forged, stray, or stale (previous-query) message cannot be
+// accepted as the answer. A bounded number of mismatches is tolerated so a flood of
+// spoofed datagrams cannot spin the CPU for the entire deadline window. It does not
+// close the connection — the caller decides whether to pool or close it.
+func (ns *NameServer) exchangeOnConn(connection *dns.Conn, query *dns.Msg) (*dns.Msg, error) {
+	if err := connection.SetDeadline(time.Now().Add(ns.QueryTimeout)); err != nil {
+		return nil, err
+	}
 	if err := connection.WriteMsg(query); err != nil {
 		return nil, err
 	}
-	// Read until a response that matches the query (transaction ID + question)
-	// arrives or the deadline fires, discarding unsolicited or mismatched datagrams
-	// so a forged or stray packet cannot be accepted as the answer. A bounded number
-	// of mismatches is tolerated so a flood of spoofed datagrams cannot spin the CPU
-	// for the entire deadline window.
 	const maxMismatchedResponses = 8
 	for mismatches := 0; ; mismatches++ {
 		msg, err := connection.ReadMsg()
@@ -183,6 +226,7 @@ func (ns *NameServer) createClientForProtocol(protocol string) *client {
 	c := &client{
 		dialFunc:     nil,
 		socks5Client: nil,
+		pool:         newConnPool(),
 		Client: &dns.Client{
 			Net:     protocol,
 			UDPSize: 4096, // Enable EDNS0 for larger UDP responses


### PR DESCRIPTION
## Summary

`queryWithProtocol` dialed a fresh connection and `Close`d it for **every** query — including TCP and **DoT** (`tcp-tls`), so each query paid a full TCP, and for DoT a full **TLS**, handshake. This adds a small bounded idle-connection pool, reused one outstanding query at a time, for **stream protocols only** (UDP is unchanged).

- Each `nameServer` client dials exactly one destination, so the pool is a simple per-client idle bucket (no key map). Bounded at `maxIdleConns` (8); a surplus connection is **closed on Put**, so idle file descriptors stay bounded even though resolvers have no teardown hook.
- Idle connections older than `idleTimeout` (10s) are closed rather than reused.
- A connection returns to the pool only after a **clean exchange**; a pooled connection that fails (peer closed it while idle) is discarded and the query retried once on a fresh dial.

### Why reuse is safe
Every query already carries a **fresh random transaction ID**, and `exchangeOnConn` keeps the existing bounded-mismatch read loop. So a leftover/late response from a *previous* query sitting on a reused connection (different ID) is discarded before an answer is accepted — the same anti-spoofing mechanism, now doubling as stale-response protection. One outstanding query per connection (no pipelining) keeps this simple and correct.

## Tests / verification
- `TestConnPoolBoundsIdle`, `TestConnPoolIdleTimeout` — pool respects `maxIdle` (closes surplus) and closes idle-expired connections instead of reusing them.
- `TestNameServerTCPConnectionReuse` — 12 sequential TCP queries against a loopback DNS server (with a connection-counting listener) use **≤2 connections** (reuse), vs 12 without the pool.
- Full nameserver suite green; **`-race` clean** on the validation host.
- **Live DoT measured** on the validation host (8.8.8.8:853, `SNI=dns.google`, distinct names, sequential):
  - old (handshake every query): ~27–48 ms/query
  - new (pooled reuse): ~45 ms first (handshake), then **~5–14 ms** — i.e. warm DoT latency drops ~5× by amortizing the TLS handshake.

  (Note: an initial attempt used `1.1.1.1` with `SNI=cloudflare-dns.com`, which a middlebox on this host's path silently blackholes at the TLS handshake — SNI-selective, `openssl` with that SNI hangs identically; other SNIs and providers are fine. That is an environment quirk, not a port-853 block and not a secDNS issue.)

## Scope
`nameServer` resolver only; UDP path unchanged; no config/API change. The recursive resolver's own auth-server exchanges are out of scope (separate follow-up).