### PR TITLE
fix(resolvers): stop sharing one *dns.Msg across concurrent children (data race)

### DIFF
--- a/internal/upstream/resolvers/concurrent/nameserver/list/types.go
+++ b/internal/upstream/resolvers/concurrent/nameserver/list/types.go
@@ -34,14 +34,14 @@ func (nsl *ConcurrentNameServerList) Resolve(query *dns.Msg, depth int) (*dns.Ms
 	errCollector := make(chan error, len(*nsl))
 	wg := new(sync.WaitGroup)
 	wg.Add(len(*nsl))
-	request := func(r resolver.Resolver) {
+	request := func(r resolver.Resolver, q *dns.Msg) {
 		ok := r != nil
 		if ok {
 			resolverType := r.Type()
 			ok = resolverType != nil && resolverType.Implements(nameserver.Type())
 		}
 		if ok {
-			m, e := r.Resolve(query, depth-1)
+			m, e := r.Resolve(q, depth-1)
 			if e != nil {
 				errCollector <- e
 			} else {
@@ -56,7 +56,10 @@ func (nsl *ConcurrentNameServerList) Resolve(query *dns.Msg, depth int) (*dns.Ms
 		wg.Done()
 	}
 	for _, nameServerResolver := range *nsl {
-		go request(nameServerResolver)
+		// Hand each child its own copy: the children run concurrently and some
+		// resolvers mutate the query in place, so sharing one *dns.Msg across
+		// goroutines would be a data race.
+		go request(nameServerResolver, query.Copy())
 	}
 	go func() {
 		wg.Wait()

--- a/internal/upstream/resolvers/concurrent/nameserver/list/types_test.go
+++ b/internal/upstream/resolvers/concurrent/nameserver/list/types_test.go
@@ -85,6 +85,62 @@ func TestConcurrentListNilEntry(t *testing.T) {
 	}
 }
 
+// mutatingStub repeatedly mutates the query it is handed (like the filterOut*IfPresents
+// resolvers do), to exercise per-child message isolation in the fan-out under -race.
+type mutatingStub struct{}
+
+func (m *mutatingStub) Type() descriptor.Type { return nameserver.Type() }
+func (m *mutatingStub) TypeName() string      { return "mutatingStub" }
+func (m *mutatingStub) NameServerResolver()   {}
+func (m *mutatingStub) Resolve(query *dns.Msg, depth int) (*dns.Msg, error) {
+	for i := 0; i < 256; i++ {
+		if len(query.Question) > 0 {
+			query.Question[0].Qtype = dns.TypeAAAA
+		}
+	}
+	reply := new(dns.Msg)
+	reply.SetReply(query)
+	return reply, nil
+}
+
+// readingStub repeatedly reads the query it is handed (like a real nameServer reading
+// Id/Question before copying), so a sibling's write races a read on a shared message.
+type readingStub struct{}
+
+func (r *readingStub) Type() descriptor.Type { return nameserver.Type() }
+func (r *readingStub) TypeName() string      { return "readingStub" }
+func (r *readingStub) NameServerResolver()   {}
+func (r *readingStub) Resolve(query *dns.Msg, depth int) (*dns.Msg, error) {
+	for i := 0; i < 256; i++ {
+		_ = query.Id
+		if len(query.Question) > 0 {
+			_ = query.Question[0].Qtype
+		}
+	}
+	reply := new(dns.Msg)
+	reply.SetReply(query)
+	return reply, nil
+}
+
+// TestConcurrentListIsolatesQueryPerChild ensures the list hands each concurrent child
+// its own copy of the query: a child that mutates its message must neither corrupt the
+// caller's query (deterministic assertion below) nor race a sibling reading it (caught
+// by -race). Without per-child copies this both fails the assertion and trips the race
+// detector.
+func TestConcurrentListIsolatesQueryPerChild(t *testing.T) {
+	var list ConcurrentNameServerList = []resolverpkg.Resolver{&mutatingStub{}, &readingStub{}}
+
+	for i := 0; i < 50; i++ {
+		q := newQuery("example.com.", dns.TypeA)
+		if _, err := list.Resolve(q, 10); err != nil {
+			t.Fatalf("Resolve returned error: %v", err)
+		}
+		if q.Question[0].Qtype != dns.TypeA {
+			t.Fatalf("a child mutated the caller's shared query (Qtype=%d)", q.Question[0].Qtype)
+		}
+	}
+}
+
 func TestConcurrentListDepthLimit(t *testing.T) {
 	res := &stubNameServer{}
 	var list ConcurrentNameServerList = []resolverpkg.Resolver{res}

--- a/internal/upstream/resolvers/filter/out/a/if/aaaa/presents/types.go
+++ b/internal/upstream/resolvers/filter/out/a/if/aaaa/presents/types.go
@@ -54,10 +54,11 @@ func (fa *FilterOutAIfAAAAPresents) Resolve(query *dns.Msg, depth int) (*dns.Msg
 }
 
 func (fa *FilterOutAIfAAAAPresents) canResolveToAAAA(query *dns.Msg, depth int) (bool, error) {
-	originalQuestionType := query.Question[0].Qtype
-	query.Question[0].Qtype = dns.TypeAAAA
-	reply, err := fa.Resolver.Resolve(query, depth-1)
-	query.Question[0].Qtype = originalQuestionType
+	// Probe on a private copy: the caller's query may be shared across concurrent
+	// resolvers (e.g. concurrentNameServerList), so mutating it in place is a data race.
+	probe := query.Copy()
+	probe.Question[0].Qtype = dns.TypeAAAA
+	reply, err := fa.Resolver.Resolve(probe, depth-1)
 	if err != nil {
 		return false, err
 	}

--- a/internal/upstream/resolvers/filter/out/aaaa/if/a/presents/types.go
+++ b/internal/upstream/resolvers/filter/out/aaaa/if/a/presents/types.go
@@ -54,10 +54,11 @@ func (fa *FilterOutAAAAIfAPresents) Resolve(query *dns.Msg, depth int) (*dns.Msg
 }
 
 func (fa *FilterOutAAAAIfAPresents) canResolveToA(query *dns.Msg, depth int) (bool, error) {
-	originalQuestionType := query.Question[0].Qtype
-	query.Question[0].Qtype = dns.TypeA
-	reply, err := fa.Resolver.Resolve(query, depth-1)
-	query.Question[0].Qtype = originalQuestionType
+	// Probe on a private copy: the caller's query may be shared across concurrent
+	// resolvers (e.g. concurrentNameServerList), so mutating it in place is a data race.
+	probe := query.Copy()
+	probe.Question[0].Qtype = dns.TypeA
+	reply, err := fa.Resolver.Resolve(probe, depth-1)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
## Summary

`concurrentNameServerList.Resolve` spawned a goroutine per child and passed the **same** `*dns.Msg` to all of them. The `filterOutAIfAAAAPresents` / `filterOutAAAAIfAPresents` resolvers **mutate the query in place** — `canResolveTo*` rewrote `query.Question[0].Qtype` then restored it. Both filters satisfy the `nameServer` marker interface, so they're valid `concurrentNameServerList` members; with one in the list, a child writes `query.Question[0].Qtype` while a sibling reads/copies the same message — an unsynchronized **data race** that also queries the wrong record type upstream.

## Fix (defense in depth)
- `concurrentNameServerList` hands each child its own `query.Copy()`.
- the two filter resolvers probe on a private `query.Copy()` instead of the write-then-restore on the caller's message (matching the copy-before-mutate pattern in `nameServer`/`doh`/`dns64`/`ecs`).

## Verification
- `TestConcurrentListIsolatesQueryPerChild` — a mutating child beside a reading child; asserts the caller's query is untouched.
- **Host-verified A/B under `-race`:** on the pre-fix code the test trips the race detector (`WARNING: DATA RACE`) **and** the mutation assertion (`Qtype=28`); after the fix the concurrent + filter packages are `-race` clean.

Found by the stability/performance audit. Scope: two leaf resolvers + the one fan-out resolver; no config/API change.