### PR TITLE
fix(recursive): one server's SERVFAIL/FORMERR no longer short-circuits the sibling loop

### DIFF
--- a/internal/upstream/resolvers/recursive/servfail_test.go
+++ b/internal/upstream/resolvers/recursive/servfail_test.go
@@ -1,0 +1,66 @@
+package recursive
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestResolveWithServersSkipsServfailSibling verifies that a SERVFAIL/FORMERR from one
+// server does not short-circuit the sibling-server loop: a later server's NOERROR answer
+// wins, and only an all-failed set surfaces the failure response.
+func TestResolveWithServersSkipsServfailSibling(t *testing.T) {
+	serverA := net.ParseIP("192.0.2.1") // SERVFAIL
+	serverB := net.ParseIP("192.0.2.2") // NOERROR + answer
+
+	newR := func() *Recursive {
+		return &Recursive{
+			MaxReferrals: 16,
+			EDNSSize:     1232,
+			scoreboard:   newScoreboard(nil, 5),
+			glueCache:    make(map[string]glueCacheEntry),
+		}
+	}
+
+	query := new(dns.Msg)
+	query.SetQuestion("example.com.", dns.TypeA)
+
+	// Case 1: serverA (tried first) SERVFAILs, serverB answers -> must return the answer.
+	r := newR()
+	r.exchangeFn = func(q *dns.Msg, ip net.IP) (*dns.Msg, time.Duration, error) {
+		resp := new(dns.Msg)
+		resp.SetReply(q)
+		if ip.Equal(serverA) {
+			resp.Rcode = dns.RcodeServerFailure
+			return resp, time.Millisecond, nil
+		}
+		resp.Rcode = dns.RcodeSuccess
+		resp.Answer = append(resp.Answer, &dns.A{
+			Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.IP{1, 2, 3, 4},
+		})
+		return resp, time.Millisecond, nil
+	}
+	out, err := r.resolveWithServers(query, []net.IP{serverA, serverB}, 10, 0, false, nil)
+	if err != nil {
+		t.Fatalf("resolveWithServers error: %v", err)
+	}
+	if out.Rcode != dns.RcodeSuccess || len(out.Answer) != 1 {
+		t.Fatalf("a SERVFAIL sibling short-circuited the loop: rcode=%d answers=%d", out.Rcode, len(out.Answer))
+	}
+
+	// Case 2: every server SERVFAILs -> surface a SERVFAIL response (not a synthetic error).
+	r = newR()
+	r.exchangeFn = func(q *dns.Msg, ip net.IP) (*dns.Msg, time.Duration, error) {
+		resp := new(dns.Msg)
+		resp.SetReply(q)
+		resp.Rcode = dns.RcodeServerFailure
+		return resp, time.Millisecond, nil
+	}
+	out, err = r.resolveWithServers(query, []net.IP{serverA, serverB}, 10, 0, false, nil)
+	if err != nil || out == nil || out.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("all-SERVFAIL should surface a SERVFAIL response: out=%v err=%v", out, err)
+	}
+}

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -54,6 +54,9 @@ type Recursive struct {
 	validator      *dnssecValidator
 	log            func(msg string)
 	ecsConfig      *ecs.Config
+	// exchangeFn, when set, replaces the real network exchange (tests inject it to
+	// drive resolveWithServers deterministically); nil uses r.exchange.
+	exchangeFn func(query *dns.Msg, ip net.IP) (*dns.Msg, time.Duration, error)
 }
 
 var (
@@ -533,8 +536,15 @@ func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth i
 		return nil, err
 	}
 	question := query.Question[0]
+	exchange := r.exchange
+	if r.exchangeFn != nil {
+		exchange = r.exchangeFn
+	}
+	// A SERVFAIL/FORMERR from one server is not authoritative; remember it but keep
+	// trying the remaining servers, and only surface it if every server fails.
+	var lastFailure *dns.Msg
 	for _, ip := range servers {
-		resp, rtt, err := r.exchange(query, ip)
+		resp, rtt, err := exchange(query, ip)
 		if err != nil {
 			if r.log != nil {
 				r.log(fmt.Sprintf("exchange to %s failed: %v", ip, err))
@@ -569,8 +579,13 @@ func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth i
 				return resp, nil
 			}
 			// No answer: treat like referral handling below.
-		case dns.RcodeNameError, dns.RcodeServerFailure, dns.RcodeFormatError:
+		case dns.RcodeNameError:
+			// Definitive authenticated/authoritative non-existence; return it.
 			return resp, nil
+		case dns.RcodeServerFailure, dns.RcodeFormatError:
+			// One server could not answer; try the next, keeping this as a fallback.
+			lastFailure = resp
+			continue
 		}
 
 		if isTerminalNoData(resp, nsNames) {
@@ -593,6 +608,11 @@ func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth i
 		if err == nil {
 			return next, nil
 		}
+	}
+	// Every server either errored or returned SERVFAIL/FORMERR. Prefer surfacing a real
+	// upstream failure response over a synthetic error when one is available.
+	if lastFailure != nil {
+		return lastFailure, nil
 	}
 	return nil, errors.New("recursive resolver: all servers failed")
 }


### PR DESCRIPTION
## Summary

`resolveWithServers` grouped `NXDOMAIN`, `SERVFAIL`, and `FORMERR` into one switch case that returned the **first** server's response immediately. `NXDOMAIN` is a definitive negative answer, but a `SERVFAIL`/`FORMERR` from a single server is **not** authoritative — a sibling server in the same set may resolve the name. As written, one flaky/misbehaving server turned **every** query routed through that set into SERVFAIL.

## Fix
Split the case: `NXDOMAIN` still returns immediately; `SERVFAIL`/`FORMERR` is recorded as a fallback and the loop **continues** to the next server, surfacing the failure response only after every server has failed.

Adds a tiny injectable `exchangeFn` seam (nil in production → `r.exchange`) so the server-selection loop can be driven deterministically in tests.

## Tests / verification
- `TestResolveWithServersSkipsServfailSibling` — a first-server SERVFAIL yields the sibling's NOERROR answer; an all-SERVFAIL set surfaces a SERVFAIL response.
- Full recursive suite green; **`-race` clean** on the host.

Found by the stability/performance audit (PR 3 of the plan). No config/API change.