### PR TITLE
fix(recursive): bound out-of-band glue resolution (depth budget + name cap)

### DIFF
--- a/internal/upstream/resolvers/recursive/glue_bound_test.go
+++ b/internal/upstream/resolvers/recursive/glue_bound_test.go
@@ -1,0 +1,72 @@
+package recursive
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestResolveGlueBoundsFanout verifies that out-of-band glue resolution is bounded: a
+// referral with many glueless NS names chases at most maxGlueNamesChased of them, and a
+// resolveGlue call with no remaining depth budget does not chase glue at all.
+func TestResolveGlueBoundsFanout(t *testing.T) {
+	root := net.ParseIP("192.0.2.53")
+	newR := func() (*Recursive, *map[string]bool, *sync.Mutex) {
+		var mu sync.Mutex
+		queried := map[string]bool{}
+		r := &Recursive{
+			MaxDepth: 32, MaxReferrals: 16, EDNSSize: 1232,
+			scoreboard: newScoreboard([]RootServer{{Addresses: []net.IP{root}}}, 5),
+			glueCache:  make(map[string]glueCacheEntry),
+		}
+		r.exchangeFn = func(q *dns.Msg, ip net.IP) (*dns.Msg, time.Duration, error) {
+			name := q.Question[0].Name
+			mu.Lock()
+			queried[name] = true
+			mu.Unlock()
+			resp := new(dns.Msg)
+			resp.SetReply(q)
+			resp.Rcode = dns.RcodeSuccess
+			switch q.Question[0].Qtype {
+			case dns.TypeA:
+				resp.Answer = append(resp.Answer, &dns.A{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}, A: net.IP{1, 2, 3, 4}})
+			case dns.TypeAAAA:
+				resp.Answer = append(resp.Answer, &dns.AAAA{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60}, AAAA: net.ParseIP("2001:db8::1")})
+			}
+			return resp, time.Millisecond, nil
+		}
+		return r, &queried, &mu
+	}
+
+	var nsNames []string
+	for i := 0; i < 20; i++ {
+		nsNames = append(nsNames, fmt.Sprintf("ns%d.example.", i))
+	}
+
+	// Many glueless NS names, ample depth: only a bounded number are chased.
+	r, queried, mu := newR()
+	ips := r.resolveGlue(nsNames, new(dns.Msg), 10, nil)
+	mu.Lock()
+	n := len(*queried)
+	mu.Unlock()
+	if n > maxGlueNamesChased {
+		t.Fatalf("resolveGlue chased %d distinct NS names, want <= %d", n, maxGlueNamesChased)
+	}
+	if len(ips) == 0 {
+		t.Fatalf("expected some glue to be resolved")
+	}
+
+	// No remaining depth budget: glue is not chased at all.
+	r, queried, mu = newR()
+	_ = r.resolveGlue(nsNames, new(dns.Msg), 0, nil)
+	mu.Lock()
+	n = len(*queried)
+	mu.Unlock()
+	if n != 0 {
+		t.Fatalf("resolveGlue at depth 0 must not chase glue, but queried %d names", n)
+	}
+}

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -599,7 +599,7 @@ func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth i
 		if len(nsNames) == 0 {
 			continue
 		}
-		glueIPs := r.resolveGlue(nsNames, resp, ecsOpt)
+		glueIPs := r.resolveGlue(nsNames, resp, depth-1, ecsOpt)
 		if len(glueIPs) == 0 {
 			continue
 		}
@@ -831,11 +831,28 @@ type glueCacheEntry struct {
 	expires time.Time
 }
 
-func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, ecsOpt *dns.EDNS0_SUBNET) []net.IP {
+// maxGlueNamesChased bounds how many distinct NS names a single glueless referral will
+// trigger out-of-band glue resolution for, limiting the fan-out per referral.
+const maxGlueNamesChased = 6
+
+// resolveGlue resolves nameserver addresses for a referral. depth is the caller's
+// remaining recursion budget: out-of-band glue lookups are charged against it (NOT a
+// fresh MaxDepth reset, which let a chain of glueless referrals recurse without bound),
+// and the number of NS names chased is capped, so a single client query cannot fan out
+// into runaway upstream traffic.
+func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, depth int, ecsOpt *dns.EDNS0_SUBNET) []net.IP {
 	ips := r.extractGlue(resp)
 	now := time.Now()
+	// Dedup the NS names while consulting the glue cache for each.
+	seen := make(map[string]struct{}, len(nsNames))
+	unique := make([]string, 0, len(nsNames))
 	for _, name := range nsNames {
 		key := strings.ToLower(name)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		unique = append(unique, name)
 		r.glueCacheMutex.Lock()
 		if entry, ok := r.glueCache[key]; ok && entry.expires.After(now) {
 			ips = append(ips, entry.ips...)
@@ -845,14 +862,21 @@ func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, ecsOpt *dns.EDN
 	if len(ips) > 0 {
 		return dedupIPs(ips, r.PreferIPv6)
 	}
-	// Fallback: resolve A/AAAA for NS names using roots again (simple path)
-	for _, name := range nsNames {
+	// No in-band glue or cached glue: chase it ourselves, but only with remaining budget
+	// and only for a bounded number of names.
+	if depth <= 0 {
+		return nil
+	}
+	if len(unique) > maxGlueNamesChased {
+		unique = unique[:maxGlueNamesChased]
+	}
+	for _, name := range unique {
 		aMsg := new(dns.Msg)
 		aMsg.SetQuestion(dns.Fqdn(name), dns.TypeA)
-		aResp, _ := r.resolveIterative(aMsg, r.MaxDepth-1, ecsOpt)
+		aResp, _ := r.resolveIterative(aMsg, depth-1, ecsOpt)
 		aaaaMsg := new(dns.Msg)
 		aaaaMsg.SetQuestion(dns.Fqdn(name), dns.TypeAAAA)
-		aaaaResp, _ := r.resolveIterative(aaaaMsg, r.MaxDepth-1, ecsOpt)
+		aaaaResp, _ := r.resolveIterative(aaaaMsg, depth-1, ecsOpt)
 		collected := collectAandAAAA(aResp, aaaaResp)
 		if len(collected) > 0 {
 			r.scoreboard.register(collected)


### PR DESCRIPTION
## Summary

`resolveGlue` chased glue for a glueless referral by restarting iterative resolution at **`r.MaxDepth-1`** (a full budget reset) for **every** NS name, with the NS list **uncapped** and `referrals` reset to 0. A chain of glueless referrals therefore recursed with no monotonic bound — a single client query could amplify into runaway upstream traffic, and the repeated depth reset allowed effectively unbounded recursion depth.

## Fix
- Charge glue lookups against the **caller's remaining depth** (passed in, decremented) instead of `MaxDepth-1`, so the budget shrinks monotonically down the whole tree and a depth-exhausted referral chases no glue.
- **Dedup** the NS names and **cap** the number chased per referral (`maxGlueNamesChased=6`).

This converts an unbounded / stack-overflow recursion into a finite, depth-bounded one. The *practical* hard cap on total upstream queries per client query (a global work/deadline budget) is a separate, larger follow-up (the audit's context-deadline item); this PR removes the unbounded-recursion case and the depth-reset amplification first.

## Tests / verification
- `TestResolveGlueBoundsFanout` — 20 glueless NS names chase at most 6; a depth-0 `resolveGlue` chases none (uses the `exchangeFn` seam to count upstream lookups).
- Full recursive suite green; **`-race` clean** on the host.

Found by the stability/performance audit (P0). No config/API change.