### PR TITLE
feat(logging): add --log-level / SECDNS_LOG_LEVEL switch (the level machinery was dead code)

### DIFF
--- a/internal/logger/level.go
+++ b/internal/logger/level.go
@@ -1,6 +1,10 @@
 package logger
 
-import "github.com/rs/zerolog"
+import (
+	"strings"
+
+	"github.com/rs/zerolog"
+)
 
 type Level zerolog.Level
 
@@ -38,4 +42,27 @@ func LogLevel() Level {
 func SetLogLevel(level Level) {
 	stdoutLogger = stdoutLogger.Level(zerolog.Level(level))
 	stderrLogger = stderrLogger.Level(zerolog.Level(level))
+}
+
+// ParseLevel maps a case-insensitive level name to a Level. It reports false for an
+// unrecognized name (callers should keep the current/default level and warn).
+func ParseLevel(name string) (Level, bool) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "trace":
+		return TraceLevel, true
+	case "debug":
+		return DebugLevel, true
+	case "info":
+		return InfoLevel, true
+	case "warn", "warning":
+		return WarningLevel, true
+	case "error", "quiet":
+		return ErrorLevel, true
+	case "fatal":
+		return FatalLevel, true
+	case "off", "none", "disabled":
+		return Disabled, true
+	default:
+		return DefaultLogLevel, false
+	}
 }

--- a/internal/logger/level_test.go
+++ b/internal/logger/level_test.go
@@ -1,0 +1,42 @@
+package logger
+
+import "testing"
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Level
+		ok   bool
+	}{
+		{"trace", TraceLevel, true},
+		{"debug", DebugLevel, true},
+		{"INFO", InfoLevel, true},
+		{" warn ", WarningLevel, true},
+		{"warning", WarningLevel, true},
+		{"error", ErrorLevel, true},
+		{"quiet", ErrorLevel, true},
+		{"off", Disabled, true},
+		{"bogus", DefaultLogLevel, false},
+		{"", DefaultLogLevel, false},
+	}
+	for _, c := range cases {
+		got, ok := ParseLevel(c.in)
+		if got != c.want || ok != c.ok {
+			t.Errorf("ParseLevel(%q) = (%v,%v), want (%v,%v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestSetLogLevelRoundTrip(t *testing.T) {
+	orig := LogLevel()
+	defer SetLogLevel(orig)
+
+	SetLogLevel(DebugLevel)
+	if LogLevel() != DebugLevel {
+		t.Fatalf("after SetLogLevel(Debug), LogLevel()=%v", LogLevel())
+	}
+	SetLogLevel(ErrorLevel)
+	if LogLevel() != ErrorLevel {
+		t.Fatalf("after SetLogLevel(Error), LogLevel()=%v", LogLevel())
+	}
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zhouchenh/secDNS/internal/config"
 	"github.com/zhouchenh/secDNS/internal/core"
 	_ "github.com/zhouchenh/secDNS/internal/features"
+	"github.com/zhouchenh/secDNS/internal/logger"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -15,7 +16,26 @@ var (
 	configFilePath = flag.String("config", "", "Specify a config file")
 	version        = flag.Bool("version", false, "Print version information and exit")
 	test           = flag.Bool("test", false, "Test the config file and exit")
+	logLevel       = flag.String("log-level", "", "Log verbosity: trace|debug|info|warn|error|off (env "+core.EnvKey("log", "level")+")")
 )
+
+// applyLogLevel sets the log level from the --log-level flag, falling back to the
+// SECDNS_LOG_LEVEL env var, then the default. An unrecognized value keeps the default
+// and warns rather than aborting.
+func applyLogLevel(flagValue string) {
+	value := flagValue
+	if value == "" {
+		value = os.Getenv(core.EnvKey("log", "level"))
+	}
+	if value == "" {
+		return
+	}
+	if level, ok := logger.ParseLevel(value); ok {
+		logger.SetLogLevel(level)
+	} else {
+		logger.Warning().Msgf("config: unknown log level %q; keeping default", value)
+	}
+}
 
 func printVersion() {
 	version := core.VersionStatement()
@@ -47,6 +67,7 @@ func open(filePath string) (*os.File, error) {
 
 func main() {
 	flag.Parse()
+	applyLogLevel(*logLevel)
 	printVersion()
 	if *version {
 		return
@@ -67,12 +88,14 @@ func main() {
 		os.Exit(1)
 	}
 	_ = os.Setenv(envConfigDirPath, filepath.Dir(file.Name()))
+	configSource := file.Name()
 	instance, err := config.LoadConfig(file)
 	_ = file.Close()
 	if err != nil {
 		common.ErrOutput(common.Concatenate("config: Failed to load config: ", err))
 		os.Exit(1)
 	}
+	logger.Info().Str("source", configSource).Msg("config loaded")
 	if *test {
 		common.Output("config: Syntax is OK")
 		os.Exit(0)


### PR DESCRIPTION
## Summary

`internal/logger` has full level support (`SetLogLevel`/`LogLevel`) but **nothing ever called `SetLogLevel`**, so the level was permanently pinned to the default (`Warning`) and every `Info`/`Debug` message was invisible — the switch was dead code.

## Change
- `logger.ParseLevel` maps `trace|debug|info|warn|warning|error|quiet|off` → `Level` (case-insensitive; unrecognized → keep default, report `false`).
- `main.go` gains a `--log-level` flag and honors `SECDNS_LOG_LEVEL` (flag > env > default), applied right after `flag.Parse()` so even config-load errors respect it. An unknown value warns and keeps the default rather than aborting.
- Logs the loaded config **source** at `info` (gated; hidden by default, shown at `--log-level info`) — the first consumer of the now-live level.

**Backward-compatible:** empty/unset keeps the `Warning` default, so existing deployments are byte-identical. This is the prerequisite for the other observability items (startup summary, strict-DNSSEC diagnostic, per-query debug).

## Tests / verification
- `TestParseLevel`, `TestSetLogLevelRoundTrip`.
- End-to-end: a bad config's error prints by default and is suppressed by `--log-level off` (exit code still non-zero); the `config loaded` info line is hidden by default and shown at `--log-level info`.

From the config/logging/UX research (the keystone). No behavior change at the default level.