### PR TITLE
docs: document new options/CLI, fix the broken cache example, refresh stale text

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,12 @@ Quick start:
 - Download a released binary from GitHub releases.
 - Validate a config: `./secDNS -test -config config.json`
 - Run with a config: `./secDNS -config config.json`
+- Set log verbosity: `./secDNS -config config.json -log-level info` (levels: `trace|debug|info|warn|error|off`; also via `SECDNS_LOG_LEVEL`).
+- Read the config from stdin: `cat config.json | ./secDNS -config -`.
 
 ## Documentation
 
-* [Configuration](docs/configuration.md) - JSON schema, object layout, and examples.
+* [Configuration](docs/configuration.md) - JSON schema, object layout, examples, and the command-line flags / environment variables (`-log-level`, `SECDNS_LOG_LEVEL`, config-file discovery).
 * [Listeners](docs/listeners.md) - Available listeners such as `dnsServer` and the HTTP API, with version notes.
 * [Resolvers](docs/resolvers.md) - All upstream resolver types, capabilities, and minimum supported versions.
 * [Rules](docs/rules.md) - Rule engines for routing queries to specific resolvers.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -153,7 +153,7 @@ The following snippet wires the HTTP API listener to a cache resolver that prefe
           "type": "nameServer",
           "config": {
             "address": "1.1.1.1",
-            "timeout": 3000
+            "queryTimeout": 3
           }
         },
         "maxEntries": 50000,
@@ -170,3 +170,53 @@ The following snippet wires the HTTP API listener to a cache resolver that prefe
 
 * `prefetchThreshold`/`prefetchPercent` refresh popular entries before they expire.
 * The HTTP API exposes the cached answers via `/resolve` so monitoring systems can hit a single endpoint.
+
+## Command-Line Flags
+
+secDNS is configured primarily through the JSON config file, but a few options are set at launch:
+
+> `-config`: String _(Optional)_
+
+Path to the config file to load. Pass `-` to read the configuration from standard input. When omitted, secDNS searches for a config file as described under [Config File Discovery](#config-file-discovery).
+
+> `-test`: Boolean _(Optional)_
+
+Load and validate the configuration, print `config: Syntax is OK`, and exit without serving. Use this to check a config before deploying.
+
+> `-version`: Boolean _(Optional)_
+
+Print version information and exit.
+
+> `-log-level`: String _(Optional)_
+
+_Available in secDNS v1.4.3 and later._
+
+Log verbosity. One of `trace`, `debug`, `info`, `warn` (alias `warning`), `error` (alias `quiet`), `fatal`, or `off` (aliases `none`, `disabled`); values are case-insensitive. An unrecognized value is ignored with a warning and the default is kept. May also be set with the `SECDNS_LOG_LEVEL` environment variable; the flag takes precedence over the environment variable.
+
+Default: `warn`
+
+## Environment Variables
+
+> `SECDNS_LOG_LEVEL`
+
+_Available in secDNS v1.4.3 and later._
+
+Fallback for `-log-level` when the flag is not given. Accepts the same values.
+
+> `SECDNS_CONFIG_FILE_PATH`
+
+Path to a config file, consulted when `-config` is not given (see [Config File Discovery](#config-file-discovery)).
+
+> `SECDNS_CONFIG_DIR_PATH`
+
+Directory that contains a `config.json`, consulted when `-config` is not given. secDNS also sets this variable internally to the directory of the loaded config file, so relative paths inside the config (for example a `dnsmasqConf` `filePath`) resolve relative to the config file.
+
+## Config File Discovery
+
+When `-config` is omitted, secDNS loads the first config it finds, in this order:
+
+1. The file named by `SECDNS_CONFIG_FILE_PATH`, if that variable is set and the file opens.
+2. `config.json` inside the directory named by `SECDNS_CONFIG_DIR_PATH`, if that variable is set and the file opens.
+3. `config.json` in the current working directory.
+
+When `-config` is `-`, the configuration is read from standard input. When `-config` names a file that cannot be opened, secDNS reports the error and exits. On a successful load, secDNS logs the config source at info level.

--- a/docs/resolvers/cache.md
+++ b/docs/resolvers/cache.md
@@ -217,7 +217,7 @@ Default: `false`
 
 ### LRU Eviction
 
-The cache uses a Least Recently Used (LRU) eviction policy. When the cache reaches `maxEntries`, the least recently accessed entry is automatically removed to make room for new entries. This ensures frequently accessed domains remain cached while infrequently used ones are evicted.
+The cache uses an approximate Least Recently Used (LRU) eviction policy implemented as a CLOCK / second-chance scan. Each hit sets a "referenced" bit; when the cache reaches `maxEntries`, the evictor skips recently-referenced entries (clearing their bit) and removes the first unreferenced one. This keeps frequently accessed domains cached while infrequently used ones are evicted, without taking a writer lock on the hit path.
 
 ### TTL Management
 
@@ -236,9 +236,9 @@ The cache supports negative caching per RFC 2308:
 
 ### Thread Safety
 
-The cache is fully thread-safe and optimized for concurrent access:
-- Read operations use RWMutex for high concurrency
-- O(1) cache lookups and LRU operations
+The cache is thread-safe and optimized for concurrent reads:
+- A cache hit takes only a read lock and marks the entry recently-used with a single atomic store (a CLOCK / second-chance bit), so concurrent hits no longer serialize on the cache's writer lock
+- O(1) cache lookups and bounded eviction
 - Atomic counters for statistics
 
 ## Examples
@@ -337,7 +337,7 @@ Aggressively cache popular domains and prefetch them before expiration while all
 }
 ```
 
-This configuration refreshes any entry that has been hit 15+ times once 90% of its TTL has passed, serves stale data for up to 45 seconds while refreshing, and honors upstream cache-control hints.
+This configuration refreshes any entry that has been hit 10+ times once 90% of its TTL has passed, serves stale data for up to 45 seconds while refreshing, and honors upstream cache-control hints.
 
 ## Performance Characteristics
 

--- a/docs/resolvers/name_server.md
+++ b/docs/resolvers/name_server.md
@@ -37,6 +37,10 @@ Default: `53`
 The type of the network protocol used to communicate with the upstream DNS server, `"tcp"`, `"udp"` or `"tcp-tls"` (DNS
 over TLS).
 
+For the stream protocols (`"tcp"` and `"tcp-tls"`), secDNS reuses idle connections from a small bounded per-destination
+pool, avoiding a TCP — and, for DoT, a TLS — handshake on every query; `"udp"` dials per query. The pool size and idle
+timeout are internal constants and need no configuration.
+
 Default: `"udp"`
 
 > `queryTimeout`: Number | String _(Optional)_

--- a/docs/resolvers/recursive.md
+++ b/docs/resolvers/recursive.md
@@ -4,7 +4,7 @@ _Available in secDNS v1.3.0 and later._
 
 * Type: `recursive`
 
-The `recursive` resolver performs full iterative resolution from the IANA root hints with DNSSEC validation. It supports ECS policy controls (passthrough/add/override/strip), qname minimization, UDP-first with TCP fallback, singleflight deduplication keyed by question + ECS, and optional SOCKS5/bind connectivity. Authoritative NODATA (SOA/no-referral) replies are short-circuited. DNSSEC gating checks RRSIG times, DS->DNSKEY chains, and NSEC/NSEC3 proof coverage; AD is set only when the chain validates. See [EDNS Client Subnet](../edns_client_subnet.md) for ECS usage.
+The `recursive` resolver performs full iterative resolution from the IANA root hints with DNSSEC validation. It supports ECS policy controls (passthrough/add/override/strip), qname minimization, UDP-first with TCP fallback, singleflight deduplication keyed by question + ECS, and optional SOCKS5/bind connectivity. Authoritative NODATA (SOA/no-referral) replies are short-circuited. DNSSEC gating checks RRSIG times, DS->DNSKEY chains, and NSEC/NSEC3 proof coverage; AD is set only when the chain validates. Clients may set the CD bit to bypass strict SERVFAIL (see `honorClientCD`), and the accepted NSEC3 iteration count is bounded (see `nsec3MaxIterations`). See [EDNS Client Subnet](../edns_client_subnet.md) for ECS usage.
 
 ## Minimal Example
 
@@ -27,6 +27,8 @@ Define a recursive resolver inline (for example under `resolvers.recursive.<name
   "type": "recursive",
   "config": {
     "validateDNSSEC": "permissive",
+    "honorClientCD": true,
+    "nsec3MaxIterations": 100,
     "qnameMinimize": true,
     "ednsSize": 1232,
     "timeout": 1.5,
@@ -57,6 +59,18 @@ Define a recursive resolver inline (for example under `resolvers.recursive.<name
 DNSSEC policy. `"strict"` fails on any validation error; `"permissive"` serves the response without AD when validation fails; `"off"` skips validation and never sets AD.
 
 Default: `"permissive"`
+
+> `honorClientCD`: Boolean _(Optional)_
+
+Whether to honor the client's DNSSEC Checking Disabled (CD) bit (RFC 4035 section 3.2.2). When `true`, a query that sets CD bypasses the SERVFAIL-on-bogus behavior of `"strict"` validation and the answer is returned without the AD bit, so a client can opt out of validation. When `false`, the CD bit is ignored and the configured `validateDNSSEC` policy always applies.
+
+Default: `true`
+
+> `nsec3MaxIterations`: Number | String _(Optional)_
+
+Maximum NSEC3 hash iteration count accepted when validating denial-of-existence proofs. Proofs whose iteration count exceeds this bound are not processed, capping the per-query hashing work an attacker can force (a DoS guard). Range: 0-2500. Accepts numbers or numeric strings.
+
+Default: `100`
 
 > `qnameMinimize`: Boolean _(Optional)_
 

--- a/examples/cache-config.json
+++ b/examples/cache-config.json
@@ -1,169 +1,139 @@
 {
-  "comment": "secDNS Cache Resolver Configuration Examples",
-  "version": "1.2.0",
+  "comment": "secDNS Cache Resolver Configuration Examples. Each entry under \"examples\" is a ResolverObject ({\"type\", \"config\"}); copy the \"config\" contents into your own config. See docs/configuration.md and docs/resolvers/cache.md.",
+  "version": "1.4.3",
 
   "examples": {
 
     "basic_cache": {
       "description": "Basic caching with default settings",
       "type": "cache",
-      "resolver": {
-        "type": "nameServer",
-        "address": "8.8.8.8"
+      "config": {
+        "resolver": { "type": "nameServer", "config": { "address": "8.8.8.8" } }
       }
     },
 
     "production_cache": {
       "description": "Production-ready caching with TTL bounds and large cache size",
       "type": "cache",
-      "resolver": {
-        "type": "doh",
-        "url": "https://dns.google/dns-query"
-      },
-      "maxEntries": 50000,
-      "minTTL": 60,
-      "maxTTL": 7200,
-      "negativeTTL": 600,
-      "cleanupInterval": 120
+      "config": {
+        "resolver": { "type": "doh", "config": { "url": "https://dns.google/dns-query" } },
+        "maxEntries": 50000,
+        "minTTL": 60,
+        "maxTTL": 7200,
+        "negativeTTL": 600,
+        "cleanupInterval": 120
+      }
     },
 
     "cache_with_fallback": {
       "description": "Cache with automatic fallback to secondary DNS",
       "type": "cache",
-      "resolver": {
-        "type": "sequence",
-        "resolvers": [
-          {
-            "type": "nameServer",
-            "address": "1.1.1.1",
-            "queryTimeout": 2
-          },
-          {
-            "type": "nameServer",
-            "address": "8.8.8.8",
-            "queryTimeout": 2
-          }
-        ]
-      },
-      "maxEntries": 20000,
-      "minTTL": 30,
-      "maxTTL": 3600
+      "config": {
+        "resolver": {
+          "type": "sequence",
+          "config": [
+            { "type": "nameServer", "config": { "address": "1.1.1.1", "queryTimeout": 2 } },
+            { "type": "nameServer", "config": { "address": "8.8.8.8", "queryTimeout": 2 } }
+          ]
+        },
+        "maxEntries": 20000,
+        "minTTL": 30,
+        "maxTTL": 3600
+      }
     },
 
     "aggressive_caching": {
       "description": "Aggressive caching for slow or unreliable networks",
       "type": "cache",
-      "resolver": {
-        "type": "nameServer",
-        "address": "1.1.1.1"
-      },
-      "maxEntries": 100000,
-      "minTTL": 300,
-      "maxTTL": 86400,
-      "negativeTTL": 1800,
-      "cleanupInterval": 300
+      "config": {
+        "resolver": { "type": "nameServer", "config": { "address": "1.1.1.1" } },
+        "maxEntries": 100000,
+        "minTTL": 300,
+        "maxTTL": 86400,
+        "negativeTTL": 1800,
+        "cleanupInterval": 300
+      }
     },
 
     "privacy_focused_cache": {
       "description": "Cache with DNS-over-HTTPS and ECS privacy",
       "type": "cache",
-      "resolver": {
-        "type": "doh",
-        "url": "https://cloudflare-dns.com/dns-query",
-        "queryTimeout": 3
-      },
-      "maxEntries": 30000,
-      "minTTL": 60,
-      "maxTTL": 3600,
-      "negativeTTL": 300
+      "config": {
+        "resolver": { "type": "doh", "config": { "url": "https://cloudflare-dns.com/dns-query", "queryTimeout": 3 } },
+        "maxEntries": 30000,
+        "minTTL": 60,
+        "maxTTL": 3600,
+        "negativeTTL": 300
+      }
     },
 
     "low_memory_cache": {
       "description": "Minimal cache for memory-constrained environments",
       "type": "cache",
-      "resolver": {
-        "type": "nameServer",
-        "address": "8.8.8.8"
-      },
-      "maxEntries": 1000,
-      "minTTL": 0,
-      "maxTTL": 0,
-      "negativeTTL": 60,
-      "cleanupInterval": 30
+      "config": {
+        "resolver": { "type": "nameServer", "config": { "address": "8.8.8.8" } },
+        "maxEntries": 1000,
+        "minTTL": 0,
+        "maxTTL": 0,
+        "negativeTTL": 60,
+        "cleanupInterval": 30
+      }
     },
 
     "cache_with_dns64": {
       "description": "Cache DNS64 responses for IPv6-only networks",
       "type": "cache",
-      "resolver": {
-        "type": "dns64",
+      "config": {
         "resolver": {
-          "type": "nameServer",
-          "address": "8.8.8.8"
+          "type": "dns64",
+          "config": {
+            "resolver": { "type": "nameServer", "config": { "address": "8.8.8.8" } },
+            "prefix": "64:ff9b::"
+          }
         },
-        "prefix": "64:ff9b::/96"
-      },
-      "maxEntries": 15000,
-      "minTTL": 120,
-      "maxTTL": 3600
+        "maxEntries": 15000,
+        "minTTL": 120,
+        "maxTTL": 3600
+      }
     },
 
     "cache_with_filtering": {
-      "description": "Cache with IPv4/IPv6 filtering",
+      "description": "Cache with IPv4/IPv6 filtering (drop A when AAAA exists)",
       "type": "cache",
-      "resolver": {
-        "type": "filterOutAIfAAAAPresents",
+      "config": {
         "resolver": {
-          "type": "nameServer",
-          "address": "1.1.1.1"
-        }
-      },
-      "maxEntries": 10000,
-      "minTTL": 60,
-      "maxTTL": 3600
+          "type": "filterOutAIfAAAAPresents",
+          "config": { "type": "nameServer", "config": { "address": "1.1.1.1" } }
+        },
+        "maxEntries": 10000,
+        "minTTL": 60,
+        "maxTTL": 3600
+      }
     }
   },
 
   "complete_server_config": {
-    "description": "Complete secDNS server configuration with caching",
-    "listen": [
-      {
-        "address": "127.0.0.1",
-        "port": 53,
-        "protocol": "udp"
-      },
-      {
-        "address": "127.0.0.1",
-        "port": 53,
-        "protocol": "tcp"
-      }
+    "description": "A complete, loadable secDNS server configuration with caching",
+    "listeners": [
+      { "type": "dnsServer", "config": { "listen": "127.0.0.1", "port": 53, "protocol": "udp" } },
+      { "type": "dnsServer", "config": { "listen": "127.0.0.1", "port": 53, "protocol": "tcp" } }
     ],
-    "resolver": {
+    "defaultResolver": {
       "type": "cache",
-      "resolver": {
-        "type": "sequence",
-        "resolvers": [
-          {
-            "type": "doh",
-            "url": "https://dns.google/dns-query",
-            "queryTimeout": 2,
-            "ecsMode": "add",
-            "ecsClientSubnet": "192.168.1.0/24"
-          },
-          {
-            "type": "nameServer",
-            "address": "1.1.1.1",
-            "protocol": "tcp-tls",
-            "tlsServerName": "1dot1dot1dot1.cloudflare-dns.com",
-            "queryTimeout": 3
-          }
-        ]
-      },
-      "maxEntries": 50000,
-      "minTTL": 60,
-      "maxTTL": 7200,
-      "negativeTTL": 600,
-      "cleanupInterval": 120
+      "config": {
+        "resolver": {
+          "type": "sequence",
+          "config": [
+            { "type": "doh", "config": { "url": "https://dns.google/dns-query", "queryTimeout": 2, "ecsMode": "add", "ecsClientSubnet": "192.168.1.0/24" } },
+            { "type": "nameServer", "config": { "address": "1.1.1.1", "protocol": "tcp-tls", "tlsServerName": "1dot1dot1dot1.cloudflare-dns.com", "queryTimeout": 3 } }
+          ]
+        },
+        "maxEntries": 50000,
+        "minTTL": 60,
+        "maxTTL": 7200,
+        "negativeTTL": 600,
+        "cleanupInterval": 120
+      }
     }
   }
 }

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -19,8 +19,11 @@ import (
 	"sync"
 )
 
-// Recursive is a placeholder for a full recursive, DNSSEC-validating resolver.
-// It is scaffolded now to wire descriptors, defaults, and root hints; recursion and validation will be implemented in follow-up steps.
+// Recursive is a full recursive, DNSSEC-validating resolver. It performs iterative
+// resolution from the IANA root hints with qname minimization, UDP-first/TCP-fallback
+// exchange, an RTT/health scoreboard for server selection, singleflight deduplication,
+// optional SOCKS5/bind connectivity, and tri-state (Secure/Insecure/Bogus) DNSSEC
+// validation gated by the configured policy.
 type Recursive struct {
 	RootServers        []RootServer
 	ValidateDNSSEC     string


### PR DESCRIPTION
Reconciles the docs with the v1.4.x code (from the docs-refinement workflow; every fact verified against the source):

- **recursive.md** — document `honorClientCD` (default `true`, RFC 4035 §3.2.2) and `nsec3MaxIterations` (range 0–2500, default 100), the two registered-but-undocumented DNSSEC options; cross-reference from the intro. (`preferIPv6` is intentionally omitted — the struct field has **no descriptor filler**, so it isn't JSON-configurable.)
- **configuration.md** — add **Command-Line Flags**, **Environment Variables**, and **Config File Discovery** sections (the home for the new `--log-level` / `SECDNS_LOG_LEVEL`); fix a stale inline example that used the unrecognized `"timeout": 3000` instead of `"queryTimeout": 3` (seconds).
- **README.md** — `--log-level` + stdin quick-start lines; point the Configuration bullet at the new flags/env sections.
- **examples/cache-config.json** — **fix a broken example.** Every nested resolver used the flat `{"type","address"}` shape, but inline resolvers load their options from a `"config"` block, so they were silently parsed with all-default config; `complete_server_config` also used non-schema top-level keys. Now every nested resolver is `{"type","config"}` and the server config uses real `listeners`/`defaultResolver` keys. **Each example validates with `secDNS -test`.**
- **cache.md** — LRU / Thread-Safety sections now describe the v1.4.2 CLOCK / second-chance hit path (no per-hit writer lock); fix a prefetch-example prose number.
- **name_server.md** — note the TCP/DoT idle connection pool on `protocol`.
- **recursive/types.go** — replace the stale "placeholder … implemented in follow-up steps" doc-comment; the resolver is fully implemented.

The v1.4.3 changelog entry (for #35–#38) lands with the release PR, not here.