### PR TITLE
fix(recursive): bound the glue and trusted-key caches; remove dead DNSKEY/DS writes

### DIFF
--- a/internal/upstream/resolvers/recursive/bound_caches_test.go
+++ b/internal/upstream/resolvers/recursive/bound_caches_test.go
@@ -1,0 +1,49 @@
+package recursive
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestPruneGlueCacheBounds(t *testing.T) {
+	now := time.Now()
+	m := make(map[string]glueCacheEntry)
+	for i := 0; i < maxGlueCacheEntries+500; i++ {
+		if len(m) >= maxGlueCacheEntries {
+			pruneGlueCache(m, now)
+		}
+		m[fmt.Sprintf("ns%d.example.", i)] = glueCacheEntry{expires: now.Add(time.Hour)}
+	}
+	if len(m) > maxGlueCacheEntries {
+		t.Fatalf("glue cache not bounded: %d > %d", len(m), maxGlueCacheEntries)
+	}
+
+	// Expired entries are dropped first, live ones kept.
+	m2 := map[string]glueCacheEntry{
+		"live": {expires: now.Add(time.Hour)},
+		"dead": {expires: now.Add(-time.Hour)},
+	}
+	pruneGlueCache(m2, now)
+	if _, ok := m2["dead"]; ok {
+		t.Fatalf("expired glue entry was not pruned")
+	}
+	if _, ok := m2["live"]; !ok {
+		t.Fatalf("live glue entry was wrongly pruned")
+	}
+}
+
+func TestKeyCacheBounded(t *testing.T) {
+	now := time.Now()
+	v := newValidator()
+	v.now = func() time.Time { return now }
+	for i := 0; i < maxKeyCacheEntries+500; i++ {
+		v.storeKeyState(fmt.Sprintf("zone%d.", i), &keyState{secure: false, expires: now.Add(time.Hour)})
+	}
+	v.cacheMu.Lock()
+	n := len(v.keyCache)
+	v.cacheMu.Unlock()
+	if n > maxKeyCacheEntries {
+		t.Fatalf("key cache not bounded: %d > %d", n, maxKeyCacheEntries)
+	}
+}

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -560,9 +560,6 @@ func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth i
 
 		nsNames := extractNS(resp)
 
-		// Cache DNSKEY/DS from authority for later trust decisions.
-		r.cacheAuthDNSKEYDS(resp)
-
 		switch resp.Rcode {
 		case dns.RcodeSuccess:
 			// If answer contains the qtype or CNAME leading to it, return.
@@ -834,6 +831,28 @@ type glueCacheEntry struct {
 	expires time.Time
 }
 
+// maxGlueCacheEntries bounds the glue cache so attacker-chosen NS names cannot grow it
+// without limit (there is no teardown hook to flush it otherwise).
+const maxGlueCacheEntries = 8192
+
+// pruneGlueCache bounds m in place. Callers must hold the glue cache mutex. It first
+// drops expired entries, then, if still over a soft target, drops arbitrary entries
+// (map iteration order) until under the target.
+func pruneGlueCache(m map[string]glueCacheEntry, now time.Time) {
+	for k, e := range m {
+		if !e.expires.After(now) {
+			delete(m, k)
+		}
+	}
+	target := maxGlueCacheEntries / 2
+	for k := range m {
+		if len(m) <= target {
+			break
+		}
+		delete(m, k)
+	}
+}
+
 // maxGlueNamesChased bounds how many distinct NS names a single glueless referral will
 // trigger out-of-band glue resolution for, limiting the fan-out per referral.
 const maxGlueNamesChased = 6
@@ -884,6 +903,9 @@ func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, depth int, ecsO
 		if len(collected) > 0 {
 			r.scoreboard.register(collected)
 			r.glueCacheMutex.Lock()
+			if len(r.glueCache) >= maxGlueCacheEntries {
+				pruneGlueCache(r.glueCache, now)
+			}
 			r.glueCache[strings.ToLower(name)] = glueCacheEntry{
 				ips:     collected,
 				expires: now.Add(10 * time.Minute),
@@ -893,24 +915,6 @@ func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, depth int, ecsO
 		}
 	}
 	return dedupIPs(ips, r.PreferIPv6)
-}
-
-// cacheAuthDNSKEYDS stores DNSKEY/DS from authority section for reuse in validation.
-func (r *Recursive) cacheAuthDNSKEYDS(resp *dns.Msg) {
-	// Simple in-memory hints via glueCache structure keyed by auth name; reuse its mutex.
-	now := time.Now().Add(1 * time.Hour)
-	r.glueCacheMutex.Lock()
-	defer r.glueCacheMutex.Unlock()
-	for _, rr := range resp.Ns {
-		switch rrTyped := rr.(type) {
-		case *dns.DNSKEY:
-			key := "dnskey:" + strings.ToLower(rrTyped.Hdr.Name)
-			r.glueCache[key] = glueCacheEntry{expires: now}
-		case *dns.DS:
-			key := "ds:" + strings.ToLower(rrTyped.Hdr.Name)
-			r.glueCache[key] = glueCacheEntry{expires: now}
-		}
-	}
 }
 
 // fetchDNSKEY uses the recursive resolver itself (without revalidation) to fetch DNSKEY for a zone.

--- a/internal/upstream/resolvers/recursive/validate.go
+++ b/internal/upstream/resolvers/recursive/validate.go
@@ -388,9 +388,28 @@ func (v *dnssecValidator) trustedKeys(zone string) (*keyState, error) {
 	return state, nil
 }
 
+// maxKeyCacheEntries bounds the trusted-key cache so an attacker querying many distinct
+// signed zones cannot grow it without limit (there is no teardown hook to flush it).
+const maxKeyCacheEntries = 4096
+
 func (v *dnssecValidator) storeKeyState(zone string, st *keyState) {
 	v.cacheMu.Lock()
 	defer v.cacheMu.Unlock()
+	if len(v.keyCache) >= maxKeyCacheEntries {
+		now := v.now()
+		for k, s := range v.keyCache {
+			if !s.expires.After(now) {
+				delete(v.keyCache, k)
+			}
+		}
+		target := maxKeyCacheEntries / 2
+		for k := range v.keyCache {
+			if len(v.keyCache) <= target {
+				break
+			}
+			delete(v.keyCache, k)
+		}
+	}
 	v.keyCache[zone] = st
 }
 


### PR DESCRIPTION
## Summary
Two unbounded maps grew with attacker-chosen names and had **no teardown hook** to flush them:
- `glueCache` (out-of-band glue addresses, keyed by NS name)
- the DNSSEC validator's `keyCache` (trusted keys, keyed by zone)

Both are now **bounded**: when a map reaches its cap, an insert first drops expired entries, then (if still over a soft target) drops arbitrary entries down to the target. Caps are generous (glue 8192, keys 4096) so legitimate workloads are unaffected.

Also removes `cacheAuthDNSKEYDS`: it wrote `dnskey:`/`ds:`-prefixed `glueCache` entries that were **never read** (the only glue read uses the bare name) — pure memory growth.

## Tests / verification
- `TestPruneGlueCacheBounds`, `TestKeyCacheBounded`; full recursive suite green; **`-race` clean** on the host.

Found by the stability/performance audit (P1). No config/API change.