### PR TITLE
fix(recursive): surface the reason a strict-mode answer is classified bogus

### DIFF
--- a/internal/upstream/resolvers/recursive/policy.go
+++ b/internal/upstream/resolvers/recursive/policy.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/miekg/dns"
+	"github.com/zhouchenh/secDNS/internal/logger"
 )
 
 // DNSSEC validation policies. The shipped default is permissive; documentation
@@ -135,6 +136,16 @@ func (r *Recursive) classifyTerminal(msg *dns.Msg, q dns.Question) (secStatus, b
 		if errors.Is(err, errDNSSECMissingSig) {
 			return statusInsecure, false
 		}
+		// A broken chain or failed signature is genuine Bogus. Under strict this
+		// becomes SERVFAIL (applyPolicy) with no other operator-visible cause, so
+		// surface the discarded reason at Debug — gated behind --log-level debug, it
+		// does not flood the default (warning) level but makes the SERVFAIL
+		// diagnosable when an operator goes looking.
+		logger.Debug().
+			Str("qname", q.Name).
+			Str("qtype", dns.TypeToString[q.Qtype]).
+			Str("reason", err.Error()).
+			Msg("dnssec: answer classified bogus")
 		return statusBogus, false
 	case validated:
 		return statusSecure, true

--- a/internal/upstream/resolvers/recursive/policy_test.go
+++ b/internal/upstream/resolvers/recursive/policy_test.go
@@ -1,9 +1,14 @@
 package recursive
 
 import (
+	"bytes"
+	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
+	"github.com/zhouchenh/secDNS/internal/logger"
 )
 
 func TestApplyPolicyDecisionTable(t *testing.T) {
@@ -89,6 +94,84 @@ func TestApplyPolicyInvariants(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+// withDebugLogger redirects the package logger to a buffer at Debug level for the
+// duration of the test and restores the prior output/level afterwards.
+func withDebugLogger(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	prevOut := logger.Output()
+	prevLevel := logger.LogLevel()
+	buf := new(bytes.Buffer)
+	logger.SetOutput(buf)
+	logger.SetLogLevel(logger.DebugLevel)
+	t.Cleanup(func() {
+		logger.SetOutput(prevOut)
+		logger.SetLogLevel(prevLevel)
+	})
+	return buf
+}
+
+// TestClassifyTerminalLogsBogusReason verifies that a genuine Bogus classification
+// (here: an expired RRSIG, a non-missing-sig failure) surfaces the discarded reason
+// at Debug with the qname/qtype, so a strict-mode SERVFAIL is diagnosable.
+func TestClassifyTerminalLogsBogusReason(t *testing.T) {
+	buf := withDebugLogger(t)
+
+	r := &Recursive{ValidateDNSSEC: policyStrict, validator: newValidator()}
+	fixedNow := time.Unix(2_000_000_000, 0) // pin "now" so the RRSIG below is unambiguously expired
+	r.validator.now = func() time.Time { return fixedNow }
+
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	msg := new(dns.Msg)
+	msg.SetQuestion(q.Name, q.Qtype)
+	msg.Answer = []dns.RR{
+		&dns.A{Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}, A: net.IPv4(1, 2, 3, 4)},
+		&dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: q.Name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 60},
+			TypeCovered: dns.TypeA,
+			Inception:   1_000_000_000,
+			Expiration:  1_500_000_000, // before fixedNow -> expired -> bogus, not missing-sig
+			SignerName:  q.Name,
+		},
+	}
+
+	status, authentic := r.classifyTerminal(msg, q)
+	if status != statusBogus {
+		t.Fatalf("status = %v, want bogus", status)
+	}
+	if authentic {
+		t.Fatalf("a bogus answer must not be reported authentic")
+	}
+	out := buf.String()
+	for _, want := range []string{"answer classified bogus", "example.com.", "A", "expired"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("diagnostic missing %q; got %q", want, out)
+		}
+	}
+}
+
+// TestClassifyTerminalInsecureDoesNotLog verifies the diagnostic is reserved for
+// genuine Bogus: a missing-signature answer classifies Insecure (served in strict)
+// and must not emit the bogus diagnostic.
+func TestClassifyTerminalInsecureDoesNotLog(t *testing.T) {
+	buf := withDebugLogger(t)
+
+	r := &Recursive{ValidateDNSSEC: policyStrict, validator: newValidator()}
+	q := dns.Question{Name: "unsigned.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	msg := new(dns.Msg)
+	msg.SetQuestion(q.Name, q.Qtype)
+	msg.Answer = []dns.RR{
+		&dns.A{Hdr: dns.RR_Header{Name: q.Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}, A: net.IPv4(1, 2, 3, 4)},
+	}
+
+	status, _ := r.classifyTerminal(msg, q)
+	if status != statusInsecure {
+		t.Fatalf("status = %v, want insecure", status)
+	}
+	if strings.Contains(buf.String(), "answer classified bogus") {
+		t.Fatalf("missing-sig (insecure) must not log a bogus diagnostic; got %q", buf.String())
 	}
 }
 


### PR DESCRIPTION
## Problem

`classifyTerminal` maps a failed DNSSEC validation into the `Bogus` tri-state but **discards the error that explains why**. Under `strict`, that `Bogus` becomes a `SERVFAIL` (`applyPolicy`) with no other operator-visible cause — so an operator chasing an intermittent strict-mode SERVFAIL has nothing to distinguish an expired signature from a broken chain from a failed verification. The reason is lost at the classification boundary.

## Change

Log the discarded reason — `qname`, `qtype`, and the error text — at **Debug** in the `Bogus` branch. It is gated behind `--log-level debug` (added in v1.4.3), so the default `warning` level is **not** flooded, but the SERVFAIL becomes diagnosable the moment an operator turns the level up.

The missing-signature (`Insecure`) branch is deliberately left silent: it is **served**, not SERVFAILed, and is not a fault.

## Tests

- `TestClassifyTerminalLogsBogusReason` — a genuine Bogus (expired RRSIG) emits the diagnostic carrying the qname/qtype/reason.
- `TestClassifyTerminalInsecureDoesNotLog` — the Insecure missing-signature case stays silent.

Full `recursive` + `core` + `logger` suites green; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)