### PR TITLE
feat(config): locate the offending entry on a rejected config

### DIFF
--- a/internal/config/diagnose.go
+++ b/internal/config/diagnose.go
@@ -1,0 +1,149 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/zhouchenh/go-descriptor"
+	"github.com/zhouchenh/secDNS/pkg/listeners/server"
+	"github.com/zhouchenh/secDNS/pkg/upstream/resolver"
+)
+
+// configError is a locatable configuration error. Where the opaque ErrBadConfig
+// reported only that *something* in the file was wrong, configError names the
+// section, the offending entry (by index), and the reason — so an operator can find
+// the entry to fix instead of bisecting the whole file.
+type configError struct {
+	section string // top-level key: "listeners", "defaultResolver", "rules", or "(root)"
+	locator string // entry within the section, e.g. `index 2`; empty for the section itself
+	reason  string
+}
+
+func (e *configError) Error() string {
+	msg := "config: " + e.section
+	if e.locator != "" {
+		msg += " " + e.locator
+	}
+	return msg + ": " + e.reason
+}
+
+// typeLookup is the registry signature shared by listeners, rules, and resolvers.
+type typeLookup func(string) (descriptor.Describable, bool)
+
+// jsonKind names the JSON type of a decoded value, for diagnostics.
+func jsonKind(v interface{}) string {
+	switch v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case float64:
+		return "number"
+	case string:
+		return "string"
+	case []interface{}:
+		return "array"
+	case map[string]interface{}:
+		return "object"
+	default:
+		return fmt.Sprintf("%T", v)
+	}
+}
+
+// diagnoseConfig inspects the raw decoded JSON and returns a locatable error for the
+// first problem it can pin down, or nil if it cannot improve on the opaque verdict
+// (the caller then falls back to ErrBadConfig). It mirrors the loader's own
+// accept/reject decisions — it re-runs the same section descriptors — so it never
+// reports a problem the loader would have tolerated.
+func diagnoseConfig(data interface{}) error {
+	root, ok := data.(map[string]interface{})
+	if !ok {
+		return &configError{section: "(root)", reason: "must be a JSON object, got " + jsonKind(data)}
+	}
+	if err := diagnoseTypedArray(root, "listeners", server.Descriptor(), server.GetServerDescriptorByTypeName); err != nil {
+		return err
+	}
+	if err := diagnoseDefaultResolver(root); err != nil {
+		return err
+	}
+	// "rules" and "resolvers" are deliberately not diagnosed: the loader treats a
+	// malformed or unknown-type entry in either as non-fatal (it falls back to an
+	// empty section rather than failing the load), so they never reach this opaque-
+	// error path, and reporting one as fatal would contradict the loader. Only the
+	// sections without a default fallback — listeners and defaultResolver — can fail
+	// the describe and land here.
+	return nil
+}
+
+// diagnoseTypedArray validates that a present section is a JSON array whose entries
+// are each accepted by the section descriptor, reporting the first that is not.
+func diagnoseTypedArray(root map[string]interface{}, key string, sectionDescriptor descriptor.Describable, lookup typeLookup) error {
+	raw, present := root[key]
+	if !present {
+		return nil // absence is handled by the loader's required-section checks
+	}
+	arr, ok := raw.([]interface{})
+	if !ok {
+		return &configError{section: key, reason: "must be a JSON array, got " + jsonKind(raw)}
+	}
+	for idx, entry := range arr {
+		if reason := diagnoseTypedEntry(entry, sectionDescriptor, lookup); reason != "" {
+			return &configError{section: key, locator: fmt.Sprintf("index %d", idx), reason: reason}
+		}
+	}
+	return nil
+}
+
+// diagnoseDefaultResolver validates the required defaultResolver. A string value is a
+// reference to a named resolver: the descriptor accepts it here and the reference is
+// resolved later (a dangling name yields the registered-resolvers hint, not this
+// path), so only a malformed inline definition is reported.
+func diagnoseDefaultResolver(root map[string]interface{}) error {
+	raw, present := root["defaultResolver"]
+	if !present {
+		return &configError{section: "defaultResolver", reason: "required, but missing"}
+	}
+	if _, isString := raw.(string); isString {
+		return nil
+	}
+	if reason := diagnoseTypedEntry(raw, resolver.Descriptor(), resolver.GetResolverDescriptorByTypeName); reason != "" {
+		return &configError{section: "defaultResolver", reason: reason}
+	}
+	return nil
+}
+
+// diagnoseTypedEntry returns a reason a {type, config} entry is malformed, or "" if
+// the section descriptor accepts it. lookup, when non-nil, distinguishes an unknown
+// type from a present type with an invalid config block.
+func diagnoseTypedEntry(entry interface{}, sectionDescriptor descriptor.Describable, lookup typeLookup) string {
+	obj, ok := entry.(map[string]interface{})
+	if !ok {
+		return `entry must be a {"type", "config"} object, got ` + jsonKind(entry)
+	}
+	rawType, present := obj["type"]
+	if !present {
+		return `entry is missing the required "type" field`
+	}
+	typeName, ok := rawType.(string)
+	if !ok {
+		return `entry "type" must be a string, got ` + jsonKind(rawType)
+	}
+	if typeName == "" {
+		return `entry "type" must not be empty`
+	}
+	if lookup != nil {
+		if _, known := lookup(typeName); !known {
+			return fmt.Sprintf("unknown type %q", typeName)
+		}
+	}
+	if !describes(sectionDescriptor, entry) {
+		return fmt.Sprintf("type %q has an invalid config block", typeName)
+	}
+	return ""
+}
+
+// describes reports whether the descriptor accepts a value, using the same
+// success/failure accounting the loader applies (success > 0, failure < 1).
+func describes(d descriptor.Describable, v interface{}) bool {
+	obj, s, f := d.Describe(v)
+	return s > 0 && f < 1 && obj != nil
+}

--- a/internal/config/diagnose_test.go
+++ b/internal/config/diagnose_test.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zhouchenh/go-descriptor"
+	_ "github.com/zhouchenh/secDNS/internal/features"
+)
+
+// TestLoadConfigLocatableErrors drives the real loader with malformed configs and
+// asserts the error names the section and the offending entry, instead of the opaque
+// "Bad config". Each input is one the loader rejects; the assertion is on locality.
+func TestLoadConfigLocatableErrors(t *testing.T) {
+	cases := []struct {
+		name     string
+		json     string
+		contains []string
+	}{
+		{
+			name:     "root not an object",
+			json:     `[1, 2, 3]`,
+			contains: []string{"config:", "(root)", "must be a JSON object", "array"},
+		},
+		{
+			name:     "listeners not an array",
+			json:     `{"listeners": {}, "defaultResolver": {"type":"noAnswer","config":{}}}`,
+			contains: []string{"listeners", "must be a JSON array", "object"},
+		},
+		{
+			name: "listener unknown type",
+			json: `{
+			  "listeners": [{"type": "bogusListener", "config": {}}],
+			  "defaultResolver": {"type":"noAnswer","config":{}}
+			}`,
+			contains: []string{"listeners", "index 0", `unknown type "bogusListener"`},
+		},
+		{
+			name: "listener missing type",
+			json: `{
+			  "listeners": [{"config": {}}],
+			  "defaultResolver": {"type":"noAnswer","config":{}}
+			}`,
+			contains: []string{"listeners", "index 0", `missing the required "type"`},
+		},
+		{
+			name: "second listener is the bad one",
+			json: `{
+			  "listeners": [
+			    {"type": "dnsServer", "config": {"listen": "127.0.0.1", "port": 5353, "protocol": "udp"}},
+			    {"type": "bogusListener", "config": {}}
+			  ],
+			  "defaultResolver": {"type":"noAnswer","config":{}}
+			}`,
+			contains: []string{"listeners", "index 1", `unknown type "bogusListener"`},
+		},
+		{
+			name: "defaultResolver unknown type",
+			json: `{
+			  "listeners": [{"type": "dnsServer", "config": {"listen": "127.0.0.1", "port": 5353, "protocol": "udp"}}],
+			  "defaultResolver": {"type": "bogusResolver", "config": {}}
+			}`,
+			contains: []string{"defaultResolver", `unknown type "bogusResolver"`},
+		},
+		{
+			name: "defaultResolver missing",
+			json: `{
+			  "listeners": [{"type": "dnsServer", "config": {"listen": "127.0.0.1", "port": 5353, "protocol": "udp"}}]
+			}`,
+			contains: []string{"defaultResolver", "missing"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := LoadConfig(strings.NewReader(c.json))
+			if err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+			got := err.Error()
+			if got == ErrBadConfig.Error() {
+				t.Fatalf("error is still the opaque %q", got)
+			}
+			for _, want := range c.contains {
+				if !strings.Contains(got, want) {
+					t.Fatalf("error %q does not contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+// TestLoadConfigValidStillLoads guards against false positives: a valid config that
+// uses every diagnosed section must still load without error.
+func TestLoadConfigValidStillLoads(t *testing.T) {
+	json := `{
+	  "listeners": [
+	    {"type": "dnsServer", "config": {"listen": "127.0.0.1", "port": 5353, "protocol": "udp"}}
+	  ],
+	  "resolvers": {"noAnswer": {"noop": {}}},
+	  "rules": [],
+	  "defaultResolver": {"type": "noAnswer", "config": {}}
+	}`
+	if _, err := LoadConfig(strings.NewReader(json)); err != nil {
+		t.Fatalf("valid config failed to load: %v", err)
+	}
+}
+
+// TestDiagnoseConfigGivesUp asserts diagnoseConfig returns nil (loader falls back to
+// ErrBadConfig) when every section it inspects is individually well-formed, so it
+// never fabricates a cause.
+func TestDiagnoseConfigGivesUp(t *testing.T) {
+	data := map[string]interface{}{
+		"listeners": []interface{}{
+			map[string]interface{}{"type": "dnsServer", "config": map[string]interface{}{"listen": "127.0.0.1"}},
+		},
+		"defaultResolver": map[string]interface{}{"type": "noAnswer", "config": map[string]interface{}{}},
+	}
+	if err := diagnoseConfig(data); err != nil {
+		t.Fatalf("diagnoseConfig should give up on a well-formed shape, got %v", err)
+	}
+}
+
+// failingDescribable is registered (lookup succeeds) but rejects every config block,
+// which the real listener/resolver descriptors are too lenient to do deterministically.
+type failingDescribable struct{}
+
+func (failingDescribable) Describe(interface{}) (interface{}, int, int) { return nil, 0, 1 }
+func (failingDescribable) GetPrototype() interface{}                    { return nil }
+
+// TestDiagnoseTypedEntryInvalidConfigBlock exercises the "known type, bad config"
+// branch directly, since the shipped types accept lenient inner configs.
+func TestDiagnoseTypedEntryInvalidConfigBlock(t *testing.T) {
+	entry := map[string]interface{}{"type": "known", "config": map[string]interface{}{"x": float64(1)}}
+	lookup := func(name string) (descriptor.Describable, bool) {
+		return failingDescribable{}, name == "known" // the type is registered...
+	}
+	reason := diagnoseTypedEntry(entry, failingDescribable{}, lookup) // ...but its config is rejected
+	if !strings.Contains(reason, `type "known"`) || !strings.Contains(reason, "invalid config block") {
+		t.Fatalf("expected an invalid-config-block reason, got %q", reason)
+	}
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -23,10 +23,16 @@ func LoadConfig(r io.Reader) (core.Instance, error) {
 	rawConfig, s, f := Descriptor().Describe(data)
 	ok := s > 0 && f < 1
 	if !ok {
+		if diag := diagnoseConfig(data); diag != nil {
+			return nil, diag
+		}
 		return nil, ErrBadConfig
 	}
 	config, ok := rawConfig.(*Config)
 	if !ok || config == nil || config.Resolvers == nil {
+		if diag := diagnoseConfig(data); diag != nil {
+			return nil, diag
+		}
 		return nil, ErrBadConfig
 	}
 	if len(config.Listeners) < 1 {


### PR DESCRIPTION
## Problem

A malformed config produced a single opaque error — `config: Bad config` — with no indication of which listener, which resolver, or which section was at fault. On a large file the only recourse was to bisect it by hand.

## Change

Add a diagnostic pass (`diagnoseConfig`) that runs **only when the descriptor rejects the file**. It re-inspects the decoded JSON and reports the first locatable cause, named by section and array index:

```
config: (root): must be a JSON object, got array
config: listeners: must be a JSON array, got object
config: listeners index 0: entry is missing the required "type" field
config: listeners index 1: unknown type "bogusListener"
config: defaultResolver: unknown type "bogusResolver"
config: defaultResolver: required, but missing
```

The pass **mirrors the loader's own accept/reject decisions** — it re-runs the same section descriptors — so it never reports a problem the loader would tolerate. If it cannot pin down a cause it falls back to the original `ErrBadConfig`.

`rules` and `resolvers` are deliberately **not** diagnosed: the loader treats a bad entry in either as non-fatal (it falls back to an empty section rather than failing the load), so they never reach this opaque-error path, and flagging one as fatal would contradict the loader. Only the sections without a default fallback — `listeners` and `defaultResolver` — can fail the describe and land here.

## Tests

- `TestLoadConfigLocatableErrors` drives the **real loader** with malformed inputs and asserts section/index locality (root shape, non-array section, unknown/missing type, second-entry-is-bad, unknown defaultResolver, missing defaultResolver).
- `TestDiagnoseTypedEntryInvalidConfigBlock` covers the known-type/invalid-config branch via a fake describable (the shipped types accept lenient inner configs, so this branch can't be reached deterministically through the loader).
- `TestLoadConfigValidStillLoads` / `TestDiagnoseConfigGivesUp` guard against false positives.

Full module `go build` / `go vet` / `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)