### PR TITLE
fix(cli): exit non-zero when startup fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,12 +65,29 @@ func open(filePath string) (*os.File, error) {
 	}
 }
 
+// Process exit codes. A failed startup must be non-zero so a supervisor (systemd,
+// Docker, Kubernetes) detects it instead of treating a server that never started as a
+// clean exit.
+const (
+	exitOK       = 0 // ran to completion, or --version/--test succeeded
+	exitStartup  = 1 // a config file was named or found but could not be opened or loaded
+	exitNoConfig = 2 // no config file was specified and none could be found (usage error)
+)
+
 func main() {
 	flag.Parse()
-	applyLogLevel(*logLevel)
+	os.Exit(run(*configFilePath, *version, *test, *logLevel))
+}
+
+// run executes the program and returns the process exit code. It is separated from
+// main so the startup and exit paths are testable without spawning a process: every
+// failure path returns a non-zero code rather than calling os.Exit, and previously a
+// missing config exited 0 (a silent success) — it now exits exitNoConfig.
+func run(configFilePath string, showVersion, testOnly bool, logLevelValue string) int {
+	applyLogLevel(logLevelValue)
 	printVersion()
-	if *version {
-		return
+	if showVersion {
+		return exitOK
 	}
 	envConfigDirPath := core.EnvKey("config", "dir", "path")
 	if _, isSet := os.LookupEnv(envConfigDirPath); !isSet {
@@ -78,14 +95,18 @@ func main() {
 			_ = os.Setenv(envConfigDirPath, filepath.Dir(executablePath))
 		}
 	}
-	file, err := open(*configFilePath)
+	file, err := open(configFilePath)
 	if err != nil {
-		if *configFilePath == "" {
+		if configFilePath == "" {
+			common.ErrOutput(common.Concatenate(
+				"config: no config file found; specify one with -config <path>, set ",
+				core.EnvKey("config", "file", "path"),
+				", or place config.json next to the executable"))
 			flag.PrintDefaults()
-			os.Exit(0)
+			return exitNoConfig
 		}
 		common.ErrOutput(common.Concatenate("config: Failed to open file: ", err))
-		os.Exit(1)
+		return exitStartup
 	}
 	_ = os.Setenv(envConfigDirPath, filepath.Dir(file.Name()))
 	configSource := file.Name()
@@ -93,13 +114,14 @@ func main() {
 	_ = file.Close()
 	if err != nil {
 		common.ErrOutput(common.Concatenate("config: Failed to load config: ", err))
-		os.Exit(1)
+		return exitStartup
 	}
 	logger.Info().Str("source", configSource).Msg("config loaded")
-	if *test {
+	if testOnly {
 		common.Output("config: Syntax is OK")
-		os.Exit(0)
+		return exitOK
 	}
 	runtime.GC()
 	instance.Listen(common.ClientErrorMessageHandler, common.ServerErrorMessageHandler, common.ErrOutputErrorHandler)
+	return exitOK
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/zhouchenh/secDNS/internal/core"
+)
+
+const validConfigJSON = `{
+  "listeners": [{"type": "dnsServer", "config": {"listen": "127.0.0.1", "port": 5353, "protocol": "udp"}}],
+  "resolvers": {"noAnswer": {"default": {}}},
+  "rules": [],
+  "defaultResolver": {"type": "noAnswer", "config": {}}
+}`
+
+const invalidConfigJSON = `{
+  "listeners": [{"type": "bogusListener", "config": {}}],
+  "defaultResolver": {"type": "noAnswer", "config": {}}
+}`
+
+// writeTemp writes content to a uniquely named file in t.TempDir() and returns its path.
+func writeTemp(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	return path
+}
+
+// isolateConfigEnv points the config-discovery env vars at empty temp locations and
+// chdir's into an empty dir, so the no-config path is deterministic regardless of the
+// host or the test binary's location.
+func isolateConfigEnv(t *testing.T) {
+	t.Helper()
+	empty := t.TempDir()
+	t.Setenv(core.EnvKey("config", "file", "path"), filepath.Join(empty, "absent.json"))
+	t.Setenv(core.EnvKey("config", "dir", "path"), empty)
+
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(empty); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+}
+
+func TestRunExitCodes(t *testing.T) {
+	t.Run("version exits ok", func(t *testing.T) {
+		if code := run("", true, false, ""); code != exitOK {
+			t.Fatalf("version: got exit %d, want %d", code, exitOK)
+		}
+	})
+
+	t.Run("no config exits non-zero", func(t *testing.T) {
+		isolateConfigEnv(t)
+		if code := run("", false, false, ""); code != exitNoConfig {
+			t.Fatalf("missing config: got exit %d, want %d (a missing config must not exit 0)", code, exitNoConfig)
+		}
+	})
+
+	t.Run("named missing file exits startup-failure", func(t *testing.T) {
+		missing := filepath.Join(t.TempDir(), "does-not-exist.json")
+		if code := run(missing, false, false, ""); code != exitStartup {
+			t.Fatalf("named missing file: got exit %d, want %d", code, exitStartup)
+		}
+	})
+
+	t.Run("invalid config exits startup-failure", func(t *testing.T) {
+		path := writeTemp(t, "invalid.json", invalidConfigJSON)
+		if code := run(path, false, true, ""); code != exitStartup {
+			t.Fatalf("invalid config: got exit %d, want %d", code, exitStartup)
+		}
+	})
+
+	t.Run("valid config with --test exits ok", func(t *testing.T) {
+		path := writeTemp(t, "valid.json", validConfigJSON)
+		if code := run(path, false, true, ""); code != exitOK {
+			t.Fatalf("valid --test config: got exit %d, want %d", code, exitOK)
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Starting with **no config file** and no discoverable `config.json` printed the usage text and **exited 0**. A process supervisor (systemd, Docker, Kubernetes) reads that as a clean exit — so a server that never started looks like one that ran and finished. It is not restarted, and the operator gets no signal.

## Change

Return a non-zero exit code from every failed-startup path:

| Situation | Exit code |
|---|---|
| Ran to completion, or `--version` / `--test` succeeded | `0` |
| Config named or found but could not be opened / loaded | `1` |
| No config specified and none discoverable (usage error) | `2` (matches `flag`'s own convention) |

The missing-config message now also names the ways to point secDNS at a config, instead of only dumping flag defaults.

`main` is split into a testable `run()` that **returns** the exit code instead of calling `os.Exit`, so the startup/exit paths can be asserted without spawning a process.

## Tests

`TestRunExitCodes` covers `--version` (0), missing config (2), named-missing file (1), an invalid config (1), and a valid config under `--test` (0). Config discovery is isolated via temp dirs + env so the no-config path is deterministic on any host.

Full module `go build` / `go vet` / `go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)