### PR TITLE
harden(http,dnsmasq): guard malformed replies and bound the dnsmasq scanner

### DIFF
--- a/internal/listeners/servers/http/api/server/errors.go
+++ b/internal/listeners/servers/http/api/server/errors.go
@@ -6,6 +6,8 @@ var (
 	ErrNilHandler        = errors.New("listeners/servers/http/api/server: nil handler")
 	ErrMissingName       = errors.New("listeners/servers/http/api/server: missing name parameter")
 	ErrNameTooLong       = errors.New("listeners/servers/http/api/server: name exceeds 255 octets")
+	ErrInvalidName       = errors.New("listeners/servers/http/api/server: name is not a valid DNS name")
 	ErrUnsupportedMethod = errors.New("listeners/servers/http/api/server: unsupported method")
 	errNilReply          = errors.New("listeners/servers/http/api/server: nil reply from handler")
+	errResponsePanic     = errors.New("listeners/servers/http/api/server: failed to build response")
 )

--- a/internal/listeners/servers/http/api/server/types.go
+++ b/internal/listeners/servers/http/api/server/types.go
@@ -77,6 +77,16 @@ type queryRequest struct {
 }
 
 func (h *HTTPAPIServer) handleResolve(w http.ResponseWriter, r *http.Request, handler func(query *dns.Msg) (reply *dns.Msg), errorHandler func(err error)) {
+	// A reply from an arbitrary resolver chain may be malformed (e.g. a typed-nil RR
+	// in a section); building the JSON for it must not crash the request with a stack
+	// trace. Recover and surface a clean 502 instead. The response object is fully
+	// constructed before any bytes are written, so the headers are still unwritten here.
+	defer func() {
+		if rec := recover(); rec != nil {
+			handleIfError(fmt.Errorf("%w: %v", errResponsePanic, rec), errorHandler)
+			writeError(w, http.StatusBadGateway, errResponsePanic)
+		}
+	}()
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
 	req, err := h.parseRequest(r)
 	if err != nil {
@@ -205,6 +215,13 @@ func validateRequest(req queryRequest) (queryRequest, error) {
 	if len(req.Name) > 255 {
 		return queryRequest{}, ErrNameTooLong
 	}
+	// Reject names that cannot be represented as a DNS name (empty interior labels,
+	// labels over 63 octets, illegal structure) before they reach packing or rule
+	// matching. Type and class are intentionally left lenient (unknown values default
+	// to A / IN), preserving the documented query-shorthand behavior.
+	if _, ok := dns.IsDomainName(req.Name); !ok {
+		return queryRequest{}, ErrInvalidName
+	}
 	return req, nil
 }
 
@@ -254,31 +271,38 @@ func toHTTPResponse(msg *dns.Msg, includeRaw bool) messageJSON {
 	res := messageJSON{
 		ID:        msg.Id,
 		RCode:     dns.RcodeToString[msg.Rcode],
-		Question:  make([]questionJSON, len(msg.Question)),
-		Answer:    make([]recordJSON, len(msg.Answer)),
-		Authority: make([]recordJSON, len(msg.Ns)),
-		Extra:     make([]recordJSON, len(msg.Extra)),
+		Question:  make([]questionJSON, 0, len(msg.Question)),
+		Answer:    recordsOf(msg.Answer, includeRaw),
+		Authority: recordsOf(msg.Ns, includeRaw),
+		Extra:     recordsOf(msg.Extra, includeRaw),
 	}
-	for i, q := range msg.Question {
-		res.Question[i] = questionJSON{
+	for _, q := range msg.Question {
+		res.Question = append(res.Question, questionJSON{
 			Name:  q.Name,
 			Type:  dns.TypeToString[q.Qtype],
 			Class: dns.ClassToString[q.Qclass],
-		}
-	}
-	for i, rr := range msg.Answer {
-		res.Answer[i] = toRecord(rr, includeRaw)
-	}
-	for i, rr := range msg.Ns {
-		res.Authority[i] = toRecord(rr, includeRaw)
-	}
-	for i, rr := range msg.Extra {
-		res.Extra[i] = toRecord(rr, includeRaw)
+		})
 	}
 	return res
 }
 
+// recordsOf converts a resource-record section to JSON, skipping nil entries so a
+// malformed reply from the resolver chain cannot panic the handler.
+func recordsOf(rrs []dns.RR, includeRaw bool) []recordJSON {
+	out := make([]recordJSON, 0, len(rrs))
+	for _, rr := range rrs {
+		if rr == nil {
+			continue
+		}
+		out = append(out, toRecord(rr, includeRaw))
+	}
+	return out
+}
+
 func toRecord(rr dns.RR, includeRaw bool) recordJSON {
+	if rr == nil {
+		return recordJSON{}
+	}
 	rec := recordJSON{
 		Name:  rr.Header().Name,
 		Type:  dns.TypeToString[rr.Header().Rrtype],
@@ -335,6 +359,9 @@ func toSimpleResponse(msg *dns.Msg) []string {
 	}
 	out := make([]string, 0, len(msg.Answer))
 	for _, rr := range msg.Answer {
+		if rr == nil {
+			continue
+		}
 		if qtype != 0 && rr.Header().Rrtype != qtype {
 			continue
 		}

--- a/internal/listeners/servers/http/api/server/types_test.go
+++ b/internal/listeners/servers/http/api/server/types_test.go
@@ -348,3 +348,82 @@ func TestValidateRequestNameLength(t *testing.T) {
 		t.Fatalf("expected ErrMissingName for a blank name, got %v", err)
 	}
 }
+
+func TestValidateRequestInvalidName(t *testing.T) {
+	// A 64-octet label exceeds the 63-octet limit: under the length cap (255) but not a
+	// representable DNS name.
+	bad := strings.Repeat("a", 64) + ".example.com"
+	if _, err := validateRequest(queryRequest{Name: bad}); err != ErrInvalidName {
+		t.Fatalf("expected ErrInvalidName for an over-long label, got %v", err)
+	}
+
+	server := &HTTPAPIServer{}
+	rec := httptest.NewRecorder()
+	req := httptestRequest(http.MethodGet, "", url.Values{"name": {bad}})
+	server.handleResolve(rec, req, func(*dns.Msg) *dns.Msg {
+		t.Fatalf("handler must not run for an invalid name")
+		return nil
+	}, nil)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid-name status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleResolveSkipsNilRR(t *testing.T) {
+	server := &HTTPAPIServer{}
+	rec := httptest.NewRecorder()
+	req := httptestRequest(http.MethodGet, "", url.Values{"name": {"example.com"}})
+
+	server.handleResolve(rec, req, func(q *dns.Msg) *dns.Msg {
+		resp := new(dns.Msg)
+		resp.SetQuestion(q.Question[0].Name, q.Question[0].Qtype)
+		resp.Answer = []dns.RR{
+			nil, // an interface-nil entry must be skipped, not panic
+			&dns.A{
+				Hdr: dns.RR_Header{Name: q.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+				A:   net.IP{1, 2, 3, 4},
+			},
+		}
+		return resp
+	}, nil)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var payload messageJSON
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(payload.Answer) != 1 || payload.Answer[0].Type != "A" {
+		t.Fatalf("nil RR not skipped cleanly: %+v", payload.Answer)
+	}
+}
+
+func TestHandleResolveRecoversFromMalformedRR(t *testing.T) {
+	server := &HTTPAPIServer{}
+	rec := httptest.NewRecorder()
+	req := httptestRequest(http.MethodGet, "", url.Values{"name": {"example.com"}})
+
+	var typedNil *dns.A // a non-nil dns.RR interface wrapping a nil pointer: dereferences on Header()
+	var handlerErr error
+	server.handleResolve(rec, req, func(q *dns.Msg) *dns.Msg {
+		resp := new(dns.Msg)
+		resp.SetQuestion(q.Question[0].Name, q.Question[0].Qtype)
+		resp.Answer = []dns.RR{typedNil}
+		return resp
+	}, func(err error) { handlerErr = err })
+
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", rec.Code)
+	}
+	var payload map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if payload["error"] != errResponsePanic.Error() {
+		t.Fatalf("unexpected error payload: %v", payload)
+	}
+	if !errors.Is(handlerErr, errResponsePanic) {
+		t.Fatalf("error handler should receive the wrapped panic, got %v", handlerErr)
+	}
+}

--- a/internal/rules/providers/dnsmasq/conf/errors.go
+++ b/internal/rules/providers/dnsmasq/conf/errors.go
@@ -1,5 +1,7 @@
 package conf
 
+import "strconv"
+
 type InvalidDomainNameError string
 
 func (e InvalidDomainNameError) Error() string {
@@ -22,6 +24,16 @@ type ReadFileError struct {
 
 func (e ReadFileError) Error() string {
 	return "rules/providers/dnsmasq/conf: An error occurred while reading dnsmasq conf file \"" + e.filePath + "\" " + e.err.Error()
+}
+
+type TruncatedError struct {
+	filePath string
+	limit    int
+}
+
+func (e TruncatedError) Error() string {
+	return "rules/providers/dnsmasq/conf: dnsmasq conf file \"" + e.filePath +
+		"\" exceeded the " + strconv.Itoa(e.limit) + "-entry limit; remaining entries were ignored"
 }
 
 type NilResolverError string

--- a/internal/rules/providers/dnsmasq/conf/types.go
+++ b/internal/rules/providers/dnsmasq/conf/types.go
@@ -10,6 +10,18 @@ import (
 	"strings"
 )
 
+// maxLineBytes bounds a single config line. The default bufio.Scanner token limit is
+// 64 KiB, at which a longer line aborts the entire scan (ErrTooLong) and silently
+// drops every remaining entry; raise it so a long-but-valid line is tolerated, while
+// still bounding per-line memory.
+const maxLineBytes = 1 << 20 // 1 MiB
+
+// maxEntries is a runaway backstop set far above any real adblock/dnsmasq list (the
+// largest aggregated lists run ~1–2M entries). It bounds memory if the configured
+// path points at the wrong (e.g. multi-gigabyte) file. Reaching it is reported via
+// TruncatedError, not silent. It is a var only so a test can lower it.
+var maxEntries = 1 << 22 // 4,194,304
+
 type DnsmasqConf struct {
 	FilePath string
 	Resolver resolver.Resolver
@@ -71,7 +83,9 @@ func (d *DnsmasqConf) ensureEntries(canReceiveError bool, receiveError func(err 
 	defer func() { _ = file.Close() }()
 
 	var entries []string
+	truncated := false
 	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64<<10), maxLineBytes)
 	for scanner.Scan() {
 		line := scanner.Text()
 		if idx := strings.IndexByte(line, '#'); idx >= 0 {
@@ -100,8 +114,16 @@ func (d *DnsmasqConf) ensureEntries(canReceiveError bool, receiveError func(err 
 			continue
 		}
 		entries = append(entries, canonical)
+		if len(entries) >= maxEntries {
+			truncated = true
+			break
+		}
 	}
-	if err := scanner.Err(); err != nil {
+	if truncated {
+		if canReceiveError {
+			receiveError(TruncatedError{filePath: d.FilePath, limit: maxEntries})
+		}
+	} else if err := scanner.Err(); err != nil {
 		if canReceiveError {
 			receiveError(ReadFileError{
 				filePath: d.FilePath,

--- a/internal/rules/providers/dnsmasq/conf/types_test.go
+++ b/internal/rules/providers/dnsmasq/conf/types_test.go
@@ -120,6 +120,59 @@ func TestDnsmasqConfReset(t *testing.T) {
 	}
 }
 
+func TestProvideToleratesLongLine(t *testing.T) {
+	// A >64 KiB line (here a long comment) exceeds the default bufio.Scanner token
+	// limit. With the default buffer the scan aborts at this line and drops the valid
+	// entry after it; with the raised buffer parsing continues.
+	longComment := "#" + strings.Repeat("x", 100<<10)
+	path := writeTempConf(t, longComment+"\nserver=/example.com/8.8.8.8\n")
+	conf := &DnsmasqConf{FilePath: path, Resolver: noopResolver{}}
+
+	var domains []string
+	for conf.Provide(func(name string, r resolver.Resolver) {
+		domains = append(domains, name)
+	}, func(err error) {
+		t.Fatalf("unexpected error: %v", err)
+	}) {
+	}
+
+	if len(domains) != 1 || domains[0] != "example.com." {
+		t.Fatalf("a long line aborted the scan; got %v", domains)
+	}
+}
+
+func TestProvideTruncatesAtEntryCap(t *testing.T) {
+	defer func(prev int) { maxEntries = prev }(maxEntries)
+	maxEntries = 3
+
+	var lines []string
+	for _, d := range []string{"a", "b", "c", "d", "e"} {
+		lines = append(lines, "server=/"+d+".example.com/8.8.8.8")
+	}
+	path := writeTempConf(t, strings.Join(lines, "\n")+"\n")
+	conf := &DnsmasqConf{FilePath: path, Resolver: noopResolver{}}
+
+	var domains []string
+	var truncErr error
+	for conf.Provide(func(name string, r resolver.Resolver) {
+		domains = append(domains, name)
+	}, func(err error) {
+		truncErr = err
+	}) {
+	}
+
+	if len(domains) != 3 {
+		t.Fatalf("entry cap not enforced: got %d entries, want 3", len(domains))
+	}
+	var te TruncatedError
+	if !errors.As(truncErr, &te) {
+		t.Fatalf("want TruncatedError when the cap is hit, got %v", truncErr)
+	}
+	if !strings.Contains(te.Error(), "3-entry limit") {
+		t.Fatalf("TruncatedError should name the limit, got %q", te.Error())
+	}
+}
+
 func writeTempConf(t *testing.T, contents string) string {
 	t.Helper()
 	dir := t.TempDir()


### PR DESCRIPTION
Three defensive fixes from the audit (P2). None change correct-path behavior.

## HTTP `/resolve`

- **nil-RR panic guard.** A reply from the resolver chain carrying a nil RR in a section panicked the handler when its JSON was built (`rr.Header()` on a nil / typed-nil record). Each section is now built by appending **non-nil** records; `toRecord` / `toSimpleResponse` guard against nil; and the handler is wrapped in a `recover` that surfaces a clean **502** (`errResponsePanic`, error handler notified) instead of letting a malformed reply crash the request with a stack trace.
- **Name validation.** Reject a query name that is not a representable DNS name (empty interior labels, labels over 63 octets) up front, alongside the existing 255-octet length cap (**400** `ErrInvalidName`). Type and class stay leniently defaulted (unknown → A / IN) **by design** — the documented query shorthand.

## dnsmasq conf

- The scanner used the default **64 KiB** token limit, at which a longer line aborts the whole scan (`ErrTooLong`) and **silently drops every remaining entry**. Raise the line buffer to **1 MiB** so a long-but-valid line is tolerated.
- Add a runaway entry-count backstop (`maxEntries`, 4,194,304 — far above any real adblock list of ~1–2M) that reports a `TruncatedError` rather than truncating silently, in case the configured path points at the wrong (e.g. multi-gigabyte) file.

## Tests

- nil-RR is skipped (200, record omitted); a typed-nil RR is recovered (502, error handler notified).
- an over-long label is rejected (400).
- a >64 KiB line no longer aborts parsing; the entry cap truncates and reports via `TruncatedError`.

Full module `go build` / `go vet` / `go test ./...` green; `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)