### PR TITLE
feat(recursive): cap per-query work with a global resolution budget

### DIFF
--- a/docs/resolvers/recursive.md
+++ b/docs/resolvers/recursive.md
@@ -44,6 +44,8 @@ Define a recursive resolver inline (for example under `resolvers.recursive.<name
     "maxDepth": 32,
     "maxCNAME": 8,
     "maxReferrals": 16,
+    "maxQueries": 256,
+    "maxResolutionTime": 30,
     "socks5Proxy": "",
     "socks5Username": "",
     "socks5Password": "",
@@ -131,6 +133,27 @@ Default: `8`
 Maximum referral depth before returning `ErrLoopDetected`. Range: 1-64.
 
 Default: `16`
+
+> `maxQueries`: Number _(Optional)_
+
+Maximum number of upstream exchanges a single client query may trigger across its whole
+iterative resolution tree — referrals, CNAME restarts, and out-of-band glue chasing all
+draw from this one budget. `maxDepth` and `maxReferrals` bound how *deep* resolution
+recurses; this bounds the *total work*, so a maliciously glueless or deeply nested
+delegation cannot fan one query out into unbounded upstream traffic. When the budget is
+spent the query is answered `SERVFAIL`. Each DNSSEC DNSKEY/DS validation fetch is bounded
+independently of the main query's budget. Range: 16-1000000.
+
+Default: `256`
+
+> `maxResolutionTime`: Number | String _(Optional)_
+
+Wall-clock backstop, in seconds (floats allowed), for a single client query. `timeout`
+bounds one exchange; this bounds the whole tree, so a chain of slow or timing-out servers
+cannot keep a resolution alive far longer than any client would wait. Set to `0` to
+disable the time budget and rely on `maxQueries` plus the per-exchange `timeout` alone.
+
+Default: `30`
 
 > `socks5Proxy`: String _(Optional)_
 

--- a/internal/upstream/resolvers/recursive/budget.go
+++ b/internal/upstream/resolvers/recursive/budget.go
@@ -1,0 +1,73 @@
+package recursive
+
+import (
+	"errors"
+	"time"
+)
+
+// defaultMaxQueries bounds the number of upstream exchanges a single client query may
+// trigger across its whole iterative resolution tree when MaxQueries is unset. It is
+// generous — a legitimate resolution, even a deep one with in-band glue and DNSSEC,
+// rarely exceeds a few dozen exchanges — but finite, so a maliciously glueless or deep
+// delegation cannot fan one query out into unbounded upstream traffic.
+const defaultMaxQueries = 256
+
+// defaultMaxResolutionTime is the wall-clock backstop for a single client query when
+// MaxResolutionTime is unset. The per-exchange Timeout bounds one hop; this bounds the
+// whole tree, so a chain of slow/timing-out servers cannot keep a resolution (and its
+// goroutine) alive far longer than any client would wait. It is deliberately well above
+// real resolution latency; set MaxResolutionTime to 0 to disable it.
+const defaultMaxResolutionTime = 30 * time.Second
+
+// ErrResolutionBudgetExceeded is returned when a single client query exhausts its
+// per-query work budget (total upstream exchanges) or its wall-clock deadline. The
+// depth budget caps how DEEP iterative resolution recurses, but not how WIDE — a
+// referral can branch into a glue chase per nameserver, and each chase is itself a full
+// resolution — so without a global cap one client query could fan out into unbounded
+// upstream traffic. At the top of Resolve this surfaces as SERVFAIL.
+var ErrResolutionBudgetExceeded = errors.New("recursive resolver: per-query resolution budget exceeded")
+
+// queryBudget is the per-client-query work-and-time budget, shared across the whole
+// iterative resolution tree: referrals, CNAME chases, and out-of-band glue chasing all
+// draw from the same counter. It is created once per Resolve call and threaded through
+// the resolution functions. A single query's resolution runs in one goroutine
+// (resolveWithServers, resolveGlue, and followCNAME are all sequential — the recursive
+// resolver never fans out into goroutines), so the counter needs no synchronization.
+type queryBudget struct {
+	remaining int              // upstream exchanges left before the budget is spent
+	deadline  time.Time        // wall-clock cap; the zero time means no time limit
+	now       func() time.Time // injectable clock (tests)
+}
+
+// charge accounts for one upstream exchange. It returns ErrResolutionBudgetExceeded
+// when the deadline has passed or the exchange allowance is spent, and otherwise
+// consumes one unit. A nil budget is treated as unbudgeted (defensive — the resolution
+// paths always pass a real one).
+func (b *queryBudget) charge() error {
+	if b == nil {
+		return nil
+	}
+	if !b.deadline.IsZero() && b.now().After(b.deadline) {
+		return ErrResolutionBudgetExceeded
+	}
+	if b.remaining <= 0 {
+		return ErrResolutionBudgetExceeded
+	}
+	b.remaining--
+	return nil
+}
+
+// newBudget builds the per-query budget from the resolver's configured limits. It is
+// called once per client query (and once per DNSKEY/DS validation fetch, which is
+// bounded independently of the main query's tree).
+func (r *Recursive) newBudget() *queryBudget {
+	max := r.MaxQueries
+	if max <= 0 {
+		max = defaultMaxQueries
+	}
+	b := &queryBudget{remaining: max, now: time.Now}
+	if r.MaxResolutionTime > 0 {
+		b.deadline = b.now().Add(r.MaxResolutionTime)
+	}
+	return b
+}

--- a/internal/upstream/resolvers/recursive/budget_test.go
+++ b/internal/upstream/resolvers/recursive/budget_test.go
@@ -1,0 +1,113 @@
+package recursive
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func TestQueryBudgetChargeCount(t *testing.T) {
+	b := &queryBudget{remaining: 3, now: time.Now}
+	for i := 0; i < 3; i++ {
+		if err := b.charge(); err != nil {
+			t.Fatalf("charge %d should succeed, got %v", i, err)
+		}
+	}
+	if err := b.charge(); !errors.Is(err, ErrResolutionBudgetExceeded) {
+		t.Fatalf("charge past the allowance should fail, got %v", err)
+	}
+}
+
+func TestQueryBudgetDeadline(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	// Plenty of exchange allowance, but the deadline has already passed.
+	b := &queryBudget{remaining: 1000, deadline: now.Add(-time.Second), now: func() time.Time { return now }}
+	if err := b.charge(); !errors.Is(err, ErrResolutionBudgetExceeded) {
+		t.Fatalf("an expired deadline should fail the charge, got %v", err)
+	}
+
+	// A zero deadline means no time limit.
+	b2 := &queryBudget{remaining: 1, now: func() time.Time { return now }}
+	if err := b2.charge(); err != nil {
+		t.Fatalf("a zero deadline must not bound time, got %v", err)
+	}
+}
+
+func TestQueryBudgetNilIsUnbudgeted(t *testing.T) {
+	var b *queryBudget
+	if err := b.charge(); err != nil {
+		t.Fatalf("a nil budget must be unbudgeted, got %v", err)
+	}
+}
+
+func TestNewBudgetRespectsConfig(t *testing.T) {
+	// MaxResolutionTime 0 -> no deadline; MaxQueries carried through.
+	r := &Recursive{MaxQueries: 42, MaxResolutionTime: 0}
+	b := r.newBudget()
+	if b.remaining != 42 {
+		t.Fatalf("remaining = %d, want 42", b.remaining)
+	}
+	if !b.deadline.IsZero() {
+		t.Fatalf("MaxResolutionTime 0 must leave the deadline unset")
+	}
+
+	// MaxResolutionTime > 0 -> deadline set in the future.
+	r2 := &Recursive{MaxQueries: 5, MaxResolutionTime: time.Minute}
+	b2 := r2.newBudget()
+	if b2.deadline.IsZero() || !b2.deadline.After(time.Now()) {
+		t.Fatalf("a positive MaxResolutionTime must set a future deadline")
+	}
+
+	// MaxQueries 0 -> falls back to the default (matches a directly-constructed resolver).
+	r3 := &Recursive{}
+	if got := r3.newBudget().remaining; got != defaultMaxQueries {
+		t.Fatalf("unset MaxQueries should default to %d, got %d", defaultMaxQueries, got)
+	}
+}
+
+// TestResolveWithServersBudgetCapsExchanges drives a resolver against an upstream that
+// answers every query with a fresh in-band-glue referral — an endless delegation that
+// the depth and referral limits are set high enough not to bind. The per-query budget
+// must stop it at exactly MaxQueries exchanges and surface the budget error.
+func TestResolveWithServersBudgetCapsExchanges(t *testing.T) {
+	const maxQueries = 10
+	var exchanges int
+	r := &Recursive{
+		MaxReferrals: 1000, // high, so the referral counter is not what binds
+		MaxQueries:   maxQueries,
+		EDNSSize:     1232,
+		scoreboard:   newScoreboard(nil, 5),
+		glueCache:    make(map[string]glueCacheEntry),
+	}
+	r.exchangeFn = func(q *dns.Msg, ip net.IP) (*dns.Msg, time.Duration, error) {
+		exchanges++
+		nsName := fmt.Sprintf("ns%d.sub.example.", exchanges)
+		resp := new(dns.Msg)
+		resp.SetReply(q)
+		resp.Rcode = dns.RcodeSuccess
+		resp.Ns = []dns.RR{&dns.NS{
+			Hdr: dns.RR_Header{Name: "sub.example.", Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 60},
+			Ns:  nsName,
+		}}
+		resp.Extra = []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{Name: nsName, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.IPv4(10, 0, byte(exchanges>>8), byte(exchanges)),
+		}}
+		return resp, time.Millisecond, nil
+	}
+
+	query := new(dns.Msg)
+	query.SetQuestion("deep.example.", dns.TypeA)
+	_, err := r.resolveWithServers(query, []net.IP{net.IPv4(192, 0, 2, 1)}, 1000, 0, false, nil, r.newBudget())
+
+	if !errors.Is(err, ErrResolutionBudgetExceeded) {
+		t.Fatalf("an endless delegation should exhaust the budget, got %v", err)
+	}
+	if exchanges != maxQueries {
+		t.Fatalf("budget allowed %d exchanges, want exactly %d", exchanges, maxQueries)
+	}
+}

--- a/internal/upstream/resolvers/recursive/descriptor_defaults_test.go
+++ b/internal/upstream/resolvers/recursive/descriptor_defaults_test.go
@@ -39,4 +39,41 @@ func TestRecursiveDescriptorUsesStringEcsDefault(t *testing.T) {
 	if r.EcsMode != string(ecs.ModePassthrough) {
 		t.Fatalf("expected ecsMode default %q, got %q", ecs.ModePassthrough, r.EcsMode)
 	}
+	if r.MaxQueries != defaultMaxQueries {
+		t.Fatalf("expected maxQueries default %d, got %d", defaultMaxQueries, r.MaxQueries)
+	}
+	if r.MaxResolutionTime != defaultMaxResolutionTime {
+		t.Fatalf("expected maxResolutionTime default %v, got %v", defaultMaxResolutionTime, r.MaxResolutionTime)
+	}
+}
+
+func TestRecursiveDescriptorBudgetConfig(t *testing.T) {
+	describable, ok := resolver.GetResolverDescriptorByTypeName("recursive")
+	if !ok {
+		t.Fatalf("descriptor for recursive not registered")
+	}
+	// Explicit values, including maxResolutionTime 0 to disable the time budget.
+	cfg := map[string]interface{}{
+		"maxQueries":        float64(64),
+		"maxResolutionTime": float64(0),
+	}
+	obj, s, f := describable.Describe(cfg)
+	if s < 1 || f > 0 {
+		t.Fatalf("describe failed: success=%d failure=%d", s, f)
+	}
+	r := obj.(*Recursive)
+	if r.MaxQueries != 64 {
+		t.Fatalf("maxQueries = %d, want 64", r.MaxQueries)
+	}
+	if r.MaxResolutionTime != 0 {
+		t.Fatalf("maxResolutionTime = %v, want 0 (disabled)", r.MaxResolutionTime)
+	}
+	// A below-range maxQueries is rejected, leaving the default.
+	obj2, s2, f2 := describable.Describe(map[string]interface{}{"maxQueries": float64(1)})
+	if s2 < 1 || f2 > 0 {
+		t.Fatalf("describe failed: success=%d failure=%d", s2, f2)
+	}
+	if got := obj2.(*Recursive).MaxQueries; got != defaultMaxQueries {
+		t.Fatalf("an out-of-range maxQueries should fall back to the default %d, got %d", defaultMaxQueries, got)
+	}
 }

--- a/internal/upstream/resolvers/recursive/glue_bound_test.go
+++ b/internal/upstream/resolvers/recursive/glue_bound_test.go
@@ -49,7 +49,7 @@ func TestResolveGlueBoundsFanout(t *testing.T) {
 
 	// Many glueless NS names, ample depth: only a bounded number are chased.
 	r, queried, mu := newR()
-	ips := r.resolveGlue(nsNames, new(dns.Msg), 10, nil)
+	ips := r.resolveGlue(nsNames, new(dns.Msg), 10, nil, r.newBudget())
 	mu.Lock()
 	n := len(*queried)
 	mu.Unlock()
@@ -62,7 +62,7 @@ func TestResolveGlueBoundsFanout(t *testing.T) {
 
 	// No remaining depth budget: glue is not chased at all.
 	r, queried, mu = newR()
-	_ = r.resolveGlue(nsNames, new(dns.Msg), 0, nil)
+	_ = r.resolveGlue(nsNames, new(dns.Msg), 0, nil, r.newBudget())
 	mu.Lock()
 	n = len(*queried)
 	mu.Unlock()

--- a/internal/upstream/resolvers/recursive/servfail_test.go
+++ b/internal/upstream/resolvers/recursive/servfail_test.go
@@ -43,7 +43,7 @@ func TestResolveWithServersSkipsServfailSibling(t *testing.T) {
 		})
 		return resp, time.Millisecond, nil
 	}
-	out, err := r.resolveWithServers(query, []net.IP{serverA, serverB}, 10, 0, false, nil)
+	out, err := r.resolveWithServers(query, []net.IP{serverA, serverB}, 10, 0, false, nil, r.newBudget())
 	if err != nil {
 		t.Fatalf("resolveWithServers error: %v", err)
 	}
@@ -59,7 +59,7 @@ func TestResolveWithServersSkipsServfailSibling(t *testing.T) {
 		resp.Rcode = dns.RcodeServerFailure
 		return resp, time.Millisecond, nil
 	}
-	out, err = r.resolveWithServers(query, []net.IP{serverA, serverB}, 10, 0, false, nil)
+	out, err = r.resolveWithServers(query, []net.IP{serverA, serverB}, 10, 0, false, nil, r.newBudget())
 	if err != nil || out == nil || out.Rcode != dns.RcodeServerFailure {
 		t.Fatalf("all-SERVFAIL should surface a SERVFAIL response: out=%v err=%v", out, err)
 	}

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -37,6 +37,8 @@ type Recursive struct {
 	MaxDepth           int
 	MaxCNAME           int
 	MaxReferrals       int
+	MaxQueries         int
+	MaxResolutionTime  time.Duration
 	Socks5Proxy        string
 	Socks5Username     string
 	Socks5Password     string
@@ -66,24 +68,26 @@ var (
 	typeOfRecursive            = descriptor.TypeOfNew(new(*Recursive))
 	ErrRecursiveNotImplemented = errors.New("recursive resolver: not implemented yet")
 	defaultRecursiveConfig     = &Recursive{
-		RootServers:     defaultRootHints(),
-		ValidateDNSSEC:  "permissive",
-		QNameMinimize:   true,
-		EDNSSize:        1232,
-		Timeout:         1500 * time.Millisecond,
-		Retries:         2,
-		ProbeTopN:       5,
-		ProbeInterval:   time.Hour,
-		PreferIPv6:      false,
-		MaxDepth:        32,
-		MaxCNAME:        8,
-		MaxReferrals:    16,
-		Socks5Proxy:     "",
-		Socks5Username:  "",
-		Socks5Password:  "",
-		SendThrough:     nil,
-		EcsMode:         string(ecs.ModePassthrough),
-		EcsClientSubnet: "",
+		RootServers:       defaultRootHints(),
+		ValidateDNSSEC:    "permissive",
+		QNameMinimize:     true,
+		EDNSSize:          1232,
+		Timeout:           1500 * time.Millisecond,
+		Retries:           2,
+		ProbeTopN:         5,
+		ProbeInterval:     time.Hour,
+		PreferIPv6:        false,
+		MaxDepth:          32,
+		MaxCNAME:          8,
+		MaxReferrals:      16,
+		MaxQueries:        defaultMaxQueries,
+		MaxResolutionTime: defaultMaxResolutionTime,
+		Socks5Proxy:       "",
+		Socks5Username:    "",
+		Socks5Password:    "",
+		SendThrough:       nil,
+		EcsMode:           string(ecs.ModePassthrough),
+		EcsClientSubnet:   "",
 	}
 )
 
@@ -125,7 +129,7 @@ func (r *Recursive) Resolve(query *dns.Msg, depth int) (*dns.Msg, error) {
 	// in-flight result; the AD/SERVFAIL stamp below is per-waiter regardless.
 	key := singleflightKey(queryCopy, clientCD, clientDO)
 	result, err, _ := r.reqGroup.Do(key, func() (interface{}, error) {
-		resp, e := r.resolveIterative(queryCopy, depth, baseECS)
+		resp, e := r.resolveIterative(queryCopy, depth, baseECS, r.newBudget())
 		if e != nil {
 			return nil, e
 		}
@@ -283,6 +287,8 @@ func init() {
 			intFiller("MaxDepth", "maxDepth", 1, 128, defaultRecursiveConfig.MaxDepth),
 			intFiller("MaxCNAME", "maxCNAME", 1, 32, defaultRecursiveConfig.MaxCNAME),
 			intFiller("MaxReferrals", "maxReferrals", 1, 64, defaultRecursiveConfig.MaxReferrals),
+			intFiller("MaxQueries", "maxQueries", 16, 1000000, defaultRecursiveConfig.MaxQueries),
+			durationFillerAllowZero("MaxResolutionTime", "maxResolutionTime", defaultRecursiveConfig.MaxResolutionTime),
 			descriptor.ObjectFiller{
 				ObjectPath: descriptor.Path{"Socks5Proxy"},
 				ValueSource: descriptor.ValueSources{
@@ -392,6 +398,11 @@ func init() {
 func (r *Recursive) initialize() {
 	if len(r.RootServers) == 0 {
 		r.RootServers = defaultRootHints()
+	}
+	if r.MaxQueries <= 0 {
+		// A directly-constructed resolver (not built through the descriptor, e.g. in
+		// tests) gets the same per-query work cap as a configured one.
+		r.MaxQueries = defaultMaxQueries
 	}
 	if r.log == nil {
 		r.log = func(msg string) { common.ErrOutput(msg) }
@@ -512,15 +523,15 @@ func (r *Recursive) prepareDialers() {
 	}
 }
 
-func (r *Recursive) resolveIterative(query *dns.Msg, depth int, ecsOpt *dns.EDNS0_SUBNET) (*dns.Msg, error) {
-	return r.resolveIterativeValidated(query, depth, true, ecsOpt)
+func (r *Recursive) resolveIterative(query *dns.Msg, depth int, ecsOpt *dns.EDNS0_SUBNET, b *queryBudget) (*dns.Msg, error) {
+	return r.resolveIterativeValidated(query, depth, true, ecsOpt, b)
 }
 
-func (r *Recursive) resolveIterativeNoValidate(query *dns.Msg, depth int, ecsOpt *dns.EDNS0_SUBNET) (*dns.Msg, error) {
-	return r.resolveIterativeValidated(query, depth, false, ecsOpt)
+func (r *Recursive) resolveIterativeNoValidate(query *dns.Msg, depth int, ecsOpt *dns.EDNS0_SUBNET, b *queryBudget) (*dns.Msg, error) {
+	return r.resolveIterativeValidated(query, depth, false, ecsOpt, b)
 }
 
-func (r *Recursive) resolveIterativeValidated(query *dns.Msg, depth int, validate bool, ecsOpt *dns.EDNS0_SUBNET) (*dns.Msg, error) {
+func (r *Recursive) resolveIterativeValidated(query *dns.Msg, depth int, validate bool, ecsOpt *dns.EDNS0_SUBNET, b *queryBudget) (*dns.Msg, error) {
 	if depth <= 0 {
 		return nil, resolver.ErrLoopDetected
 	}
@@ -528,10 +539,10 @@ func (r *Recursive) resolveIterativeValidated(query *dns.Msg, depth int, validat
 		return nil, err
 	}
 	servers := r.scoreboard.pickRoots(r.PreferIPv6)
-	return r.resolveWithServers(query, servers, depth, 0, validate, ecsOpt)
+	return r.resolveWithServers(query, servers, depth, 0, validate, ecsOpt, b)
 }
 
-func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth int, referrals int, validate bool, ecsOpt *dns.EDNS0_SUBNET) (*dns.Msg, error) {
+func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth int, referrals int, validate bool, ecsOpt *dns.EDNS0_SUBNET, b *queryBudget) (*dns.Msg, error) {
 	if len(servers) == 0 {
 		return nil, errors.New("recursive resolver: no servers available")
 	}
@@ -547,6 +558,12 @@ func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth i
 	// trying the remaining servers, and only surface it if every server fails.
 	var lastFailure *dns.Msg
 	for _, ip := range servers {
+		// Every upstream exchange across this query's whole tree — including the glue
+		// chases and CNAME restarts reached below — draws from one shared budget; when
+		// it is spent the resolution stops instead of fanning out further.
+		if err := b.charge(); err != nil {
+			return nil, err
+		}
 		resp, rtt, err := exchange(query, ip)
 		if err != nil {
 			if r.log != nil {
@@ -569,7 +586,7 @@ func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth i
 						return final, nil
 					}
 				} else if follow != nil && depth > 0 {
-					next, err := r.resolveIterativeValidated(follow, depth-1, validate, ecsOpt)
+					next, err := r.resolveIterativeValidated(follow, depth-1, validate, ecsOpt, b)
 					if err != nil {
 						return nil, err
 					}
@@ -599,14 +616,19 @@ func (r *Recursive) resolveWithServers(query *dns.Msg, servers []net.IP, depth i
 		if len(nsNames) == 0 {
 			continue
 		}
-		glueIPs := r.resolveGlue(nsNames, resp, depth-1, ecsOpt)
+		glueIPs := r.resolveGlue(nsNames, resp, depth-1, ecsOpt, b)
 		if len(glueIPs) == 0 {
 			continue
 		}
 		ordered := r.scoreboard.pickFrom(glueIPs, r.PreferIPv6, r.ProbeTopN)
-		next, err := r.resolveWithServers(query, ordered, depth-1, referrals+1, validate, ecsOpt)
+		next, err := r.resolveWithServers(query, ordered, depth-1, referrals+1, validate, ecsOpt, b)
 		if err == nil {
 			return next, nil
+		}
+		// The budget is global to this query; once it is spent, stop descending into
+		// sibling servers rather than re-failing on each.
+		if errors.Is(err, ErrResolutionBudgetExceeded) {
+			return nil, err
 		}
 	}
 	// Every server either errored or returned SERVFAIL/FORMERR. Prefer surfacing a real
@@ -862,7 +884,7 @@ const maxGlueNamesChased = 6
 // fresh MaxDepth reset, which let a chain of glueless referrals recurse without bound),
 // and the number of NS names chased is capped, so a single client query cannot fan out
 // into runaway upstream traffic.
-func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, depth int, ecsOpt *dns.EDNS0_SUBNET) []net.IP {
+func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, depth int, ecsOpt *dns.EDNS0_SUBNET, b *queryBudget) []net.IP {
 	ips := r.extractGlue(resp)
 	now := time.Now()
 	// Dedup the NS names while consulting the glue cache for each.
@@ -895,10 +917,10 @@ func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, depth int, ecsO
 	for _, name := range unique {
 		aMsg := new(dns.Msg)
 		aMsg.SetQuestion(dns.Fqdn(name), dns.TypeA)
-		aResp, _ := r.resolveIterative(aMsg, depth-1, ecsOpt)
+		aResp, _ := r.resolveIterative(aMsg, depth-1, ecsOpt, b)
 		aaaaMsg := new(dns.Msg)
 		aaaaMsg.SetQuestion(dns.Fqdn(name), dns.TypeAAAA)
-		aaaaResp, _ := r.resolveIterative(aaaaMsg, depth-1, ecsOpt)
+		aaaaResp, _ := r.resolveIterative(aaaaMsg, depth-1, ecsOpt, b)
 		collected := collectAandAAAA(aResp, aaaaResp)
 		if len(collected) > 0 {
 			r.scoreboard.register(collected)
@@ -918,17 +940,19 @@ func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, depth int, ecsO
 }
 
 // fetchDNSKEY uses the recursive resolver itself (without revalidation) to fetch DNSKEY for a zone.
+// Each validation fetch carries its own fresh budget — it is bounded independently of
+// the client query's main resolution tree (and of the other per-zone fetches).
 func (r *Recursive) fetchDNSKEY(name string) (*dns.Msg, error) {
 	msg := new(dns.Msg)
 	msg.SetQuestion(dns.Fqdn(name), dns.TypeDNSKEY)
-	return r.resolveIterativeValidated(msg, r.MaxDepth-1, false, nil)
+	return r.resolveIterativeValidated(msg, r.MaxDepth-1, false, nil, r.newBudget())
 }
 
 // fetchDS uses the recursive resolver to fetch DS for the zone (without revalidation).
 func (r *Recursive) fetchDS(name string) (*dns.Msg, error) {
 	msg := new(dns.Msg)
 	msg.SetQuestion(dns.Fqdn(name), dns.TypeDS)
-	return r.resolveIterativeValidated(msg, r.MaxDepth-1, false, nil)
+	return r.resolveIterativeValidated(msg, r.MaxDepth-1, false, nil, r.newBudget())
 }
 
 func parentZone(name string) string {
@@ -1260,6 +1284,43 @@ func durationFiller(field, jsonKey string, def time.Duration) descriptor.ObjectF
 						ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
 							seconds, err := strconv.ParseFloat(strings.TrimSpace(original.(string)), 64)
 							if err != nil || seconds <= 0 {
+								return nil, false
+							}
+							return time.Duration(seconds * float64(time.Second)), true
+						},
+					},
+				},
+			},
+			descriptor.DefaultValue{Value: def},
+		},
+	}
+}
+
+// durationFillerAllowZero is durationFiller but accepts 0 (and rejects negatives), so a
+// config value of 0 can disable an optional time budget rather than falling back to the
+// default.
+func durationFillerAllowZero(field, jsonKey string, def time.Duration) descriptor.ObjectFiller {
+	return descriptor.ObjectFiller{
+		ObjectPath: descriptor.Path{field},
+		ValueSource: descriptor.ValueSources{
+			descriptor.ObjectAtPath{
+				ObjectPath: descriptor.Path{jsonKey},
+				AssignableKind: descriptor.AssignableKinds{
+					descriptor.ConvertibleKind{
+						Kind: descriptor.KindFloat64,
+						ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+							seconds, ok := original.(float64)
+							if !ok || seconds < 0 {
+								return nil, false
+							}
+							return time.Duration(seconds * float64(time.Second)), true
+						},
+					},
+					descriptor.ConvertibleKind{
+						Kind: descriptor.KindString,
+						ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+							seconds, err := strconv.ParseFloat(strings.TrimSpace(original.(string)), 64)
+							if err != nil || seconds < 0 {
 								return nil, false
 							}
 							return time.Duration(seconds * float64(time.Second)), true


### PR DESCRIPTION
## Problem

`maxDepth` and `maxReferrals` bound how **deep** iterative resolution recurses, but not how **wide**. A referral can branch into an out-of-band glue chase *per nameserver*, and each chase is itself a full resolution from the roots — so a maliciously glueless or deeply nested delegation can fan a single client query out into exponentially many upstream exchanges. The depth limit alone does not bound the total work, which is the practical amplification vector this closes.

## Change

A per-query **budget**, shared across the whole iterative tree (referrals, CNAME restarts, and glue chasing all draw from one counter), created once per `Resolve` call and threaded through the resolution functions. It is charged once at the single `exchange` chokepoint; when the work allowance or the optional wall-clock deadline is spent, the resolution stops and the query is answered `SERVFAIL`.

- Background scoreboard probes are **not** on this path and are unaffected.
- Each DNSSEC DNSKEY/DS validation fetch carries its **own fresh budget**, bounded independently of the main query's tree.
- A single query's resolution runs in one goroutine (the recursive resolver never fans out into goroutines), so the counter needs no synchronization.

## New options

| Option | Default | Range | Meaning |
|--------|---------|-------|---------|
| `maxQueries` | `256` | 16–1000000 | Total upstream exchanges per client query. Generous (a legit deep+DNSSEC resolution rarely exceeds a few dozen) but finite. |
| `maxResolutionTime` | `30` (s) | ≥0, `0` disables | Wall-clock backstop for the whole query, complementing the per-exchange `timeout`. |

A directly-constructed resolver and a config with an out-of-range value both fall back to the defaults.

## Tests

- `queryBudget` count / deadline / nil accounting.
- Descriptor parsing of both options, including `maxResolutionTime: 0` to disable the deadline and out-of-range `maxQueries` fallback.
- **Integration:** an endless in-band-glue delegation is driven through `resolveWithServers`; it stops at **exactly `maxQueries`** exchanges and surfaces `ErrResolutionBudgetExceeded`.

Full module `go build` / `go vet` / `go test ./...` green; changed files `gofmt`-clean. `-race` to be run on the validation host before the v1.4.5 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)