### PR TITLE
perf(recursive): resolve A and AAAA glue addresses concurrently

### DIFF
--- a/internal/upstream/resolvers/recursive/budget.go
+++ b/internal/upstream/resolvers/recursive/budget.go
@@ -2,6 +2,7 @@ package recursive
 
 import (
 	"errors"
+	"sync/atomic"
 	"time"
 )
 
@@ -30,11 +31,11 @@ var ErrResolutionBudgetExceeded = errors.New("recursive resolver: per-query reso
 // queryBudget is the per-client-query work-and-time budget, shared across the whole
 // iterative resolution tree: referrals, CNAME chases, and out-of-band glue chasing all
 // draw from the same counter. It is created once per Resolve call and threaded through
-// the resolution functions. A single query's resolution runs in one goroutine
-// (resolveWithServers, resolveGlue, and followCNAME are all sequential — the recursive
-// resolver never fans out into goroutines), so the counter needs no synchronization.
+// the resolution functions. Glue chasing resolves the A and AAAA addresses of each
+// nameserver concurrently, so the counter is atomic; the deadline and clock are set once
+// at construction and only read thereafter.
 type queryBudget struct {
-	remaining int              // upstream exchanges left before the budget is spent
+	remaining atomic.Int64     // upstream exchanges left before the budget is spent
 	deadline  time.Time        // wall-clock cap; the zero time means no time limit
 	now       func() time.Time // injectable clock (tests)
 }
@@ -42,7 +43,9 @@ type queryBudget struct {
 // charge accounts for one upstream exchange. It returns ErrResolutionBudgetExceeded
 // when the deadline has passed or the exchange allowance is spent, and otherwise
 // consumes one unit. A nil budget is treated as unbudgeted (defensive — the resolution
-// paths always pass a real one).
+// paths always pass a real one). It is safe to call from multiple goroutines: the
+// allowance is claimed with a single atomic decrement, so exactly the configured number
+// of charges succeed even under the concurrent glue fan-out.
 func (b *queryBudget) charge() error {
 	if b == nil {
 		return nil
@@ -50,10 +53,9 @@ func (b *queryBudget) charge() error {
 	if !b.deadline.IsZero() && b.now().After(b.deadline) {
 		return ErrResolutionBudgetExceeded
 	}
-	if b.remaining <= 0 {
+	if b.remaining.Add(-1) < 0 {
 		return ErrResolutionBudgetExceeded
 	}
-	b.remaining--
 	return nil
 }
 
@@ -65,7 +67,8 @@ func (r *Recursive) newBudget() *queryBudget {
 	if max <= 0 {
 		max = defaultMaxQueries
 	}
-	b := &queryBudget{remaining: max, now: time.Now}
+	b := &queryBudget{now: time.Now}
+	b.remaining.Store(int64(max))
 	if r.MaxResolutionTime > 0 {
 		b.deadline = b.now().Add(r.MaxResolutionTime)
 	}

--- a/internal/upstream/resolvers/recursive/budget_test.go
+++ b/internal/upstream/resolvers/recursive/budget_test.go
@@ -4,14 +4,24 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 )
 
+// budgetWith builds a queryBudget with a given allowance and clock (the atomic counter
+// cannot be set in a struct literal).
+func budgetWith(remaining int64, deadline time.Time, now func() time.Time) *queryBudget {
+	b := &queryBudget{deadline: deadline, now: now}
+	b.remaining.Store(remaining)
+	return b
+}
+
 func TestQueryBudgetChargeCount(t *testing.T) {
-	b := &queryBudget{remaining: 3, now: time.Now}
+	b := budgetWith(3, time.Time{}, time.Now)
 	for i := 0; i < 3; i++ {
 		if err := b.charge(); err != nil {
 			t.Fatalf("charge %d should succeed, got %v", i, err)
@@ -24,16 +34,42 @@ func TestQueryBudgetChargeCount(t *testing.T) {
 
 func TestQueryBudgetDeadline(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
+	clock := func() time.Time { return now }
 	// Plenty of exchange allowance, but the deadline has already passed.
-	b := &queryBudget{remaining: 1000, deadline: now.Add(-time.Second), now: func() time.Time { return now }}
+	b := budgetWith(1000, now.Add(-time.Second), clock)
 	if err := b.charge(); !errors.Is(err, ErrResolutionBudgetExceeded) {
 		t.Fatalf("an expired deadline should fail the charge, got %v", err)
 	}
 
 	// A zero deadline means no time limit.
-	b2 := &queryBudget{remaining: 1, now: func() time.Time { return now }}
+	b2 := budgetWith(1, time.Time{}, clock)
 	if err := b2.charge(); err != nil {
 		t.Fatalf("a zero deadline must not bound time, got %v", err)
+	}
+}
+
+// TestQueryBudgetConcurrentChargeExact asserts that, even when many goroutines charge
+// the same budget at once (the concurrent glue fan-out), exactly the allowance succeeds.
+func TestQueryBudgetConcurrentChargeExact(t *testing.T) {
+	const allowance = 50
+	const goroutines = 200
+	b := budgetWith(allowance, time.Time{}, time.Now)
+
+	var ok atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			if b.charge() == nil {
+				ok.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if got := ok.Load(); got != allowance {
+		t.Fatalf("concurrent charges succeeded %d times, want exactly %d", got, allowance)
 	}
 }
 
@@ -48,8 +84,8 @@ func TestNewBudgetRespectsConfig(t *testing.T) {
 	// MaxResolutionTime 0 -> no deadline; MaxQueries carried through.
 	r := &Recursive{MaxQueries: 42, MaxResolutionTime: 0}
 	b := r.newBudget()
-	if b.remaining != 42 {
-		t.Fatalf("remaining = %d, want 42", b.remaining)
+	if got := b.remaining.Load(); got != 42 {
+		t.Fatalf("remaining = %d, want 42", got)
 	}
 	if !b.deadline.IsZero() {
 		t.Fatalf("MaxResolutionTime 0 must leave the deadline unset")
@@ -64,7 +100,7 @@ func TestNewBudgetRespectsConfig(t *testing.T) {
 
 	// MaxQueries 0 -> falls back to the default (matches a directly-constructed resolver).
 	r3 := &Recursive{}
-	if got := r3.newBudget().remaining; got != defaultMaxQueries {
+	if got := r3.newBudget().remaining.Load(); got != int64(defaultMaxQueries) {
 		t.Fatalf("unset MaxQueries should default to %d, got %d", defaultMaxQueries, got)
 	}
 }

--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -915,12 +915,28 @@ func (r *Recursive) resolveGlue(nsNames []string, resp *dns.Msg, depth int, ecsO
 		unique = unique[:maxGlueNamesChased]
 	}
 	for _, name := range unique {
-		aMsg := new(dns.Msg)
-		aMsg.SetQuestion(dns.Fqdn(name), dns.TypeA)
-		aResp, _ := r.resolveIterative(aMsg, depth-1, ecsOpt, b)
-		aaaaMsg := new(dns.Msg)
-		aaaaMsg.SetQuestion(dns.Fqdn(name), dns.TypeAAAA)
-		aaaaResp, _ := r.resolveIterative(aaaaMsg, depth-1, ecsOpt, b)
+		// Resolve the A and AAAA glue addresses concurrently: they are independent, each
+		// is a full (and slow) sub-resolution, and waiting on them in series doubles the
+		// latency of chasing a glueless referral. Both draw from the shared atomic query
+		// budget, so the fan-out stays globally capped. Each goroutine has its own query
+		// message and writes a distinct result; ecsOpt is only read (cloned) downstream.
+		fqdn := dns.Fqdn(name)
+		var aResp, aaaaResp *dns.Msg
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			aMsg := new(dns.Msg)
+			aMsg.SetQuestion(fqdn, dns.TypeA)
+			aResp, _ = r.resolveIterative(aMsg, depth-1, ecsOpt, b)
+		}()
+		go func() {
+			defer wg.Done()
+			aaaaMsg := new(dns.Msg)
+			aaaaMsg.SetQuestion(fqdn, dns.TypeAAAA)
+			aaaaResp, _ = r.resolveIterative(aaaaMsg, depth-1, ecsOpt, b)
+		}()
+		wg.Wait()
 		collected := collectAandAAAA(aResp, aaaaResp)
 		if len(collected) > 0 {
 			r.scoreboard.register(collected)


### PR DESCRIPTION
## Change

Chasing a glueless referral resolved each nameserver's **A** and then its **AAAA** address in series, paying the slower of two independent sub-resolutions twice over per name. They are now resolved **concurrently** and joined on a `WaitGroup`, roughly halving the latency of a glue chase.

## Concurrency safety

The two goroutines share the per-query resolution budget (added in v1.4.5), so its counter is now an **`atomic.Int64`** claimed with a single decrement — exactly the configured number of charges still succeed under the fan-out.

- Each goroutine uses its **own** query message and writes a **distinct** result variable (joined via `WaitGroup`).
- The shared ECS option is only **read** (cloned) downstream; the scoreboard and glue cache were already mutex-guarded.
- The fan-out stays **globally bounded**: every spawned exchange charges the budget *first*, so the live goroutine count cannot exceed the remaining budget.

## Tests

- `TestQueryBudgetConcurrentChargeExact` — 200 goroutines charging one budget; **exactly** the allowance (50) succeeds.
- Existing glue-bound and budget-cap tests pass unchanged with the A/AAAA queries now parallel.

## Validation

- Local: `go build` / `go vet` / `go test ./...` green; changed files `gofmt`-clean.
- **Host `-race` (the gate for this one):** `go test -race -count=3 ./internal/upstream/resolvers/recursive/` **ok**, and full `go test -race ./...` → 27 packages ok, **no data races**, exit 0 (Go 1.24.7 + gcc on the validation host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)