### PR TITLE
release: v1.4.6

### DIFF
--- a/docs/version_history.md
+++ b/docs/version_history.md
@@ -1,5 +1,22 @@
 # Version History
 
+## v1.4.6 - 2026.06.05
+
+Concurrent Glue Resolution
+
+This release resolves the IPv4 and IPv6 addresses of a nameserver concurrently when
+chasing a glueless referral, cutting glue-resolution latency. Configuration is
+backward-compatible.
+
+* recursive: resolve A and AAAA glue addresses concurrently. Chasing a glueless referral
+  previously resolved each nameserver's A address and then its AAAA address in series, so
+  the slower of two independent sub-resolutions was paid twice over per name. The two are
+  now resolved in parallel and joined, roughly halving the latency of a glue chase. The
+  per-query resolution budget the two share is now an atomic counter claimed with a single
+  decrement, so exactly the configured number of upstream exchanges still succeeds under
+  the fan-out, and the live goroutine count stays bounded by the remaining budget (every
+  spawned exchange charges the budget before running).
+
 ## v1.4.5 - 2026.06.05
 
 Per-Query Resolution Budget

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	name    = "secDNS"
-	version = "1.4.5"
+	version = "1.4.6"
 	build   = ""
 	intro   = "A DNS Resolver with custom rules."
 )


### PR DESCRIPTION
Bump version to **1.4.6** and add the version-history entry.

Change since v1.4.5:

| PR | Change |
|----|--------|
| #50 | recursive: resolve A and AAAA glue addresses concurrently — roughly halves glue-chase latency; the shared per-query budget is now atomic |

Configuration is backward-compatible.

**Validation:** `go build` / `go vet` / `go test ./...` green; `go test -race -count=3` on the recursive package and full `go test -race ./...` **clean on the validation host** (27 packages ok, no data races).

🤖 Generated with [Claude Code](https://claude.com/claude-code)