### PR TITLE
feat(authoritative): record store and authoritative resolver

### DIFF
--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -16,6 +16,7 @@ import (
 
 	_ "github.com/zhouchenh/secDNS/internal/upstream/resolvers/address"
 	_ "github.com/zhouchenh/secDNS/internal/upstream/resolvers/alias"
+	_ "github.com/zhouchenh/secDNS/internal/upstream/resolvers/authoritative"
 	_ "github.com/zhouchenh/secDNS/internal/upstream/resolvers/cache"
 	_ "github.com/zhouchenh/secDNS/internal/upstream/resolvers/concurrent/nameserver/list"
 	_ "github.com/zhouchenh/secDNS/internal/upstream/resolvers/dns64"

--- a/internal/recordstore/registry.go
+++ b/internal/recordstore/registry.go
@@ -1,0 +1,47 @@
+package recordstore
+
+import (
+	"sync"
+	"time"
+)
+
+// DefaultName is the store joined when a resolver or admin listener omits a store name,
+// so the common single-store config needs no naming.
+const DefaultName = "default"
+
+// gcInterval is how often a store's background sweep reclaims expired records. Reads
+// already skip expired records, so this only bounds memory; it is a var so tests can
+// shorten it.
+var gcInterval = 10 * time.Second
+
+var (
+	registryMu sync.Mutex
+	registry   = map[string]*Store{}
+)
+
+// GetOrCreate returns the shared store for name, creating it (and starting its
+// background GC sweep) on first use. An empty name maps to DefaultName, so a resolver
+// and an admin listener that both omit the store name share one store regardless of
+// which is configured first.
+func GetOrCreate(name string) *Store {
+	if name == "" {
+		name = DefaultName
+	}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	if s, ok := registry[name]; ok {
+		return s
+	}
+	s := New()
+	registry[name] = s
+	go s.gcLoop()
+	return s
+}
+
+func (s *Store) gcLoop() {
+	t := time.NewTicker(gcInterval)
+	defer t.Stop()
+	for range t.C {
+		s.sweep()
+	}
+}

--- a/internal/recordstore/store.go
+++ b/internal/recordstore/store.go
@@ -1,0 +1,125 @@
+// Package recordstore holds the in-memory authoritative records served by the
+// authoritative resolver and mutated by the admin API. A store is shared by name (see
+// registry.go) so a resolver and an admin listener configured with the same store name
+// operate on one set of records.
+package recordstore
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Record is a single authoritative RRset for a {name, type} pair.
+type Record struct {
+	Name      string    // canonical FQDN, lowercase
+	Type      uint16    // dns.TypeTXT / TypeA / TypeAAAA / TypeCNAME
+	Values    []string  // presentation-form values (IP strings, CNAME target, TXT strings)
+	TTL       uint32    // DNS TTL served in answers
+	ExpiresAt time.Time // store auto-removal time; the zero time means no expiry
+}
+
+func (rec Record) expired(now time.Time) bool {
+	return !rec.ExpiresAt.IsZero() && !now.Before(rec.ExpiresAt)
+}
+
+type key struct {
+	name   string
+	rrtype uint16
+}
+
+// Store is an in-memory, TTL-aware, concurrency-safe set of authoritative records keyed
+// by {canonical name, type}. Expired records are never returned and are reclaimed by a
+// background sweep.
+type Store struct {
+	mu      sync.RWMutex
+	records map[key]Record
+	now     func() time.Time
+}
+
+// New returns an empty store. Use GetOrCreate for the shared, registry-backed instance
+// that a resolver and an admin listener join by name.
+func New() *Store {
+	return &Store{records: make(map[key]Record), now: time.Now}
+}
+
+// canonicalName lowercases and fqdn-normalizes a name for keying and lookup.
+func canonicalName(name string) string {
+	return strings.ToLower(dns.Fqdn(name))
+}
+
+// Set inserts or replaces the record for its {name, type}. The name is canonicalized.
+func (s *Store) Set(rec Record) {
+	rec.Name = canonicalName(rec.Name)
+	s.mu.Lock()
+	s.records[key{rec.Name, rec.Type}] = rec
+	s.mu.Unlock()
+}
+
+// Get returns the live record for {name, type}, or false if it is absent or expired.
+func (s *Store) Get(name string, rrtype uint16) (Record, bool) {
+	k := key{canonicalName(name), rrtype}
+	s.mu.RLock()
+	rec, ok := s.records[k]
+	s.mu.RUnlock()
+	if !ok || rec.expired(s.now()) {
+		return Record{}, false
+	}
+	return rec, true
+}
+
+// Delete removes the record for {name, type}; it reports whether one was present
+// (regardless of expiry).
+func (s *Store) Delete(name string, rrtype uint16) bool {
+	k := key{canonicalName(name), rrtype}
+	s.mu.Lock()
+	_, ok := s.records[k]
+	delete(s.records, k)
+	s.mu.Unlock()
+	return ok
+}
+
+// List returns all live (non-expired) records.
+func (s *Store) List() []Record {
+	now := s.now()
+	s.mu.RLock()
+	out := make([]Record, 0, len(s.records))
+	for _, rec := range s.records {
+		if !rec.expired(now) {
+			out = append(out, rec)
+		}
+	}
+	s.mu.RUnlock()
+	return out
+}
+
+// HasName reports whether any live record exists for the canonical name, of any type.
+// The authoritative resolver uses it to answer NODATA (the name exists but not the
+// queried type) versus NXDOMAIN (the name does not exist at all).
+func (s *Store) HasName(name string) bool {
+	cn := canonicalName(name)
+	now := s.now()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for k, rec := range s.records {
+		if k.name == cn && !rec.expired(now) {
+			return true
+		}
+	}
+	return false
+}
+
+// sweep removes every expired record. It is called periodically by the GC loop and is
+// safe to call concurrently with reads and writes.
+func (s *Store) sweep() {
+	now := s.now()
+	s.mu.Lock()
+	for k, rec := range s.records {
+		if rec.expired(now) {
+			delete(s.records, k)
+		}
+	}
+	s.mu.Unlock()
+}

--- a/internal/recordstore/store_test.go
+++ b/internal/recordstore/store_test.go
@@ -1,0 +1,105 @@
+package recordstore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func TestStoreSetGetReplaceDelete(t *testing.T) {
+	s := New()
+	s.Set(Record{Name: "Foo.Example.COM", Type: dns.TypeTXT, Values: []string{"a"}, TTL: 60})
+
+	// Lookup is case- and trailing-dot-insensitive.
+	rec, ok := s.Get("foo.example.com.", dns.TypeTXT)
+	if !ok {
+		t.Fatalf("record not found after Set")
+	}
+	if rec.Name != "foo.example.com." || rec.Values[0] != "a" {
+		t.Fatalf("unexpected record: %+v", rec)
+	}
+
+	// Set replaces by {name, type}.
+	s.Set(Record{Name: "foo.example.com", Type: dns.TypeTXT, Values: []string{"b"}, TTL: 30})
+	rec, _ = s.Get("foo.example.com", dns.TypeTXT)
+	if len(rec.Values) != 1 || rec.Values[0] != "b" || rec.TTL != 30 {
+		t.Fatalf("Set did not replace: %+v", rec)
+	}
+
+	// A different type for the same name is independent.
+	if _, ok := s.Get("foo.example.com", dns.TypeA); ok {
+		t.Fatalf("unexpected A record")
+	}
+
+	if !s.Delete("FOO.example.com.", dns.TypeTXT) {
+		t.Fatalf("Delete should report the record was present")
+	}
+	if _, ok := s.Get("foo.example.com", dns.TypeTXT); ok {
+		t.Fatalf("record still present after Delete")
+	}
+	if s.Delete("foo.example.com", dns.TypeTXT) {
+		t.Fatalf("Delete of an absent record should report false")
+	}
+}
+
+func TestStoreExpiry(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s := New()
+	s.now = func() time.Time { return now }
+
+	s.Set(Record{Name: "live.example.", Type: dns.TypeA, Values: []string{"1.2.3.4"}, TTL: 60, ExpiresAt: now.Add(time.Minute)})
+	s.Set(Record{Name: "perm.example.", Type: dns.TypeA, Values: []string{"5.6.7.8"}, TTL: 60}) // zero ExpiresAt = no expiry
+
+	if _, ok := s.Get("live.example.", dns.TypeA); !ok {
+		t.Fatalf("unexpired record should be live")
+	}
+
+	// Advance past the expiry: the record is no longer returned, and HasName/List drop it.
+	now = now.Add(2 * time.Minute)
+	if _, ok := s.Get("live.example.", dns.TypeA); ok {
+		t.Fatalf("expired record must not be returned")
+	}
+	if s.HasName("live.example.") {
+		t.Fatalf("HasName must ignore expired records")
+	}
+	if _, ok := s.Get("perm.example.", dns.TypeA); !ok {
+		t.Fatalf("a zero-expiry record must never expire")
+	}
+
+	// sweep reclaims the expired entry; the permanent one stays.
+	s.sweep()
+	if got := len(s.List()); got != 1 {
+		t.Fatalf("after sweep, want 1 live record, got %d", got)
+	}
+}
+
+func TestStoreHasNameDistinguishesNodataFromNxdomain(t *testing.T) {
+	s := New()
+	s.Set(Record{Name: "exists.example.", Type: dns.TypeA, Values: []string{"1.2.3.4"}, TTL: 60})
+
+	if !s.HasName("exists.example.") {
+		t.Fatalf("HasName should be true for a name with a record")
+	}
+	if _, ok := s.Get("exists.example.", dns.TypeTXT); ok {
+		t.Fatalf("a different type should miss (NODATA), got a hit")
+	}
+	if s.HasName("absent.example.") {
+		t.Fatalf("HasName should be false for an unknown name (NXDOMAIN)")
+	}
+}
+
+func TestGetOrCreateSharesByName(t *testing.T) {
+	a := GetOrCreate("shared-test")
+	b := GetOrCreate("shared-test")
+	if a != b {
+		t.Fatalf("GetOrCreate must return the same store for the same name")
+	}
+	if GetOrCreate("") != GetOrCreate(DefaultName) {
+		t.Fatalf("an empty name must map to DefaultName")
+	}
+	c := GetOrCreate("other-test")
+	if c == a {
+		t.Fatalf("distinct names must map to distinct stores")
+	}
+}

--- a/internal/upstream/resolvers/authoritative/types.go
+++ b/internal/upstream/resolvers/authoritative/types.go
@@ -1,0 +1,186 @@
+// Package authoritative implements a resolver that answers from a process-local
+// recordstore.Store instead of forwarding upstream. Names routed to it (via rules)
+// return the store's records; unknown names get NXDOMAIN, known names without the
+// queried type get NODATA, each with a synthesized SOA in the authority section for
+// negative caching. The store is populated out of band — typically by the admin API —
+// and shared by name, so a resolver and an admin listener configured with the same
+// store name operate on one record set.
+package authoritative
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/miekg/dns"
+	"github.com/zhouchenh/go-descriptor"
+	"github.com/zhouchenh/secDNS/internal/common"
+	"github.com/zhouchenh/secDNS/internal/recordstore"
+	"github.com/zhouchenh/secDNS/pkg/upstream/resolver"
+)
+
+// Authoritative answers from a shared record store. DNSSEC signing, zone transfer, and
+// dynamic DNS updates are out of scope; answers are unsigned (Insecure).
+type Authoritative struct {
+	Store       string // shared store name; empty joins recordstore.DefaultName
+	NegativeTTL uint32 // SOA TTL / MINTTL for NXDOMAIN and NODATA answers
+
+	initOnce sync.Once
+	store    *recordstore.Store
+}
+
+var typeOfAuthoritative = descriptor.TypeOfNew(new(*Authoritative))
+
+func (a *Authoritative) Type() descriptor.Type {
+	return typeOfAuthoritative
+}
+
+func (a *Authoritative) TypeName() string {
+	return "authoritative"
+}
+
+func (a *Authoritative) init() {
+	a.store = recordstore.GetOrCreate(a.Store)
+	if a.NegativeTTL == 0 {
+		a.NegativeTTL = 60
+	}
+}
+
+func (a *Authoritative) Resolve(query *dns.Msg, depth int) (*dns.Msg, error) {
+	if depth < 0 {
+		return nil, resolver.ErrLoopDetected
+	}
+	if query == nil {
+		return nil, resolver.ErrNilQuery
+	}
+	if len(query.Question) == 0 {
+		return nil, resolver.ErrNotSupportedQuestion
+	}
+	a.initOnce.Do(a.init)
+
+	q := query.Question[0]
+	resp := new(dns.Msg)
+	resp.SetReply(query)
+	resp.Authoritative = true
+
+	// Exact {name, type} hit.
+	if rec, ok := a.store.Get(q.Name, q.Qtype); ok {
+		resp.Answer = append(resp.Answer, recordToRRs(rec, q.Name, q.Qclass)...)
+		return resp, nil
+	}
+	// A CNAME at the name answers any other type (the requester re-queries the target).
+	if q.Qtype != dns.TypeCNAME {
+		if cn, ok := a.store.Get(q.Name, dns.TypeCNAME); ok {
+			resp.Answer = append(resp.Answer, recordToRRs(cn, q.Name, q.Qclass)...)
+			return resp, nil
+		}
+	}
+	// No matching record: NODATA when the name exists for another type, else NXDOMAIN.
+	if a.store.HasName(q.Name) {
+		resp.Rcode = dns.RcodeSuccess
+	} else {
+		resp.Rcode = dns.RcodeNameError
+	}
+	resp.Ns = append(resp.Ns, a.soa(q.Name))
+	return resp, nil
+}
+
+// recordToRRs renders a stored record as resource records owned by the queried name.
+// Malformed values (e.g. an unparseable IP) are skipped rather than served.
+func recordToRRs(rec recordstore.Record, owner string, qclass uint16) []dns.RR {
+	hdr := func(rrtype uint16) dns.RR_Header {
+		return dns.RR_Header{Name: owner, Rrtype: rrtype, Class: qclass, Ttl: rec.TTL}
+	}
+	var out []dns.RR
+	switch rec.Type {
+	case dns.TypeA:
+		for _, v := range rec.Values {
+			if ip := net.ParseIP(strings.TrimSpace(v)); ip != nil && ip.To4() != nil {
+				out = append(out, &dns.A{Hdr: hdr(dns.TypeA), A: ip.To4()})
+			}
+		}
+	case dns.TypeAAAA:
+		for _, v := range rec.Values {
+			ip := net.ParseIP(strings.TrimSpace(v))
+			if ip != nil && ip.To4() == nil && ip.To16() != nil {
+				out = append(out, &dns.AAAA{Hdr: hdr(dns.TypeAAAA), AAAA: ip.To16()})
+			}
+		}
+	case dns.TypeCNAME:
+		if len(rec.Values) > 0 {
+			out = append(out, &dns.CNAME{Hdr: hdr(dns.TypeCNAME), Target: dns.Fqdn(rec.Values[0])})
+		}
+	case dns.TypeTXT:
+		out = append(out, &dns.TXT{Hdr: hdr(dns.TypeTXT), Txt: append([]string(nil), rec.Values...)})
+	}
+	return out
+}
+
+// soa synthesizes the authority-section SOA for a negative answer. The owner is the
+// queried name (the resolver does not track a true zone apex), and the reserved
+// .invalid. TLD (RFC 6761) is used for the placeholder mname/rname; the MINTTL drives
+// the downstream negative cache.
+func (a *Authoritative) soa(owner string) *dns.SOA {
+	return &dns.SOA{
+		Hdr:     dns.RR_Header{Name: owner, Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: a.NegativeTTL},
+		Ns:      "ns.invalid.",
+		Mbox:    "hostmaster.invalid.",
+		Serial:  1,
+		Refresh: 3600,
+		Retry:   600,
+		Expire:  86400,
+		Minttl:  a.NegativeTTL,
+	}
+}
+
+func init() {
+	if err := resolver.RegisterResolver(&descriptor.Descriptor{
+		Type: typeOfAuthoritative,
+		Filler: descriptor.Fillers{
+			descriptor.ObjectFiller{
+				ObjectPath: descriptor.Path{"Store"},
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath:     descriptor.Path{"store"},
+						AssignableKind: descriptor.KindString,
+					},
+					descriptor.DefaultValue{Value: ""},
+				},
+			},
+			descriptor.ObjectFiller{
+				ObjectPath: descriptor.Path{"NegativeTTL"},
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath: descriptor.Path{"negativeTTL"},
+						AssignableKind: descriptor.AssignableKinds{
+							descriptor.ConvertibleKind{
+								Kind: descriptor.KindFloat64,
+								ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+									v := int(original.(float64))
+									if v < 0 || v > 2147483647 {
+										return nil, false
+									}
+									return uint32(v), true
+								},
+							},
+							descriptor.ConvertibleKind{
+								Kind: descriptor.KindString,
+								ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+									v, err := strconv.Atoi(strings.TrimSpace(original.(string)))
+									if err != nil || v < 0 || v > 2147483647 {
+										return nil, false
+									}
+									return uint32(v), true
+								},
+							},
+						},
+					},
+					descriptor.DefaultValue{Value: uint32(60)},
+				},
+			},
+		},
+	}); err != nil {
+		common.ErrOutput(err)
+	}
+}

--- a/internal/upstream/resolvers/authoritative/types_test.go
+++ b/internal/upstream/resolvers/authoritative/types_test.go
@@ -1,0 +1,146 @@
+package authoritative
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/zhouchenh/secDNS/internal/recordstore"
+	resolverpkg "github.com/zhouchenh/secDNS/pkg/upstream/resolver"
+)
+
+func newResolver(t *testing.T, storeName string) (*Authoritative, *recordstore.Store) {
+	t.Helper()
+	a := &Authoritative{Store: storeName}
+	return a, recordstore.GetOrCreate(storeName)
+}
+
+func query(name string, qtype uint16) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion(dns.Fqdn(name), qtype)
+	return m
+}
+
+func TestResolveTXTHit(t *testing.T) {
+	a, store := newResolver(t, "auth-txt")
+	store.Set(recordstore.Record{Name: "_acme-challenge.example.com.", Type: dns.TypeTXT, Values: []string{"token-value"}, TTL: 60})
+
+	resp, err := a.Resolve(query("_acme-challenge.example.com", dns.TypeTXT), 4)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if !resp.Authoritative {
+		t.Fatalf("authoritative bit must be set")
+	}
+	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) != 1 {
+		t.Fatalf("expected one answer, got rcode=%d answers=%d", resp.Rcode, len(resp.Answer))
+	}
+	txt, ok := resp.Answer[0].(*dns.TXT)
+	if !ok || len(txt.Txt) != 1 || txt.Txt[0] != "token-value" {
+		t.Fatalf("unexpected TXT answer: %+v", resp.Answer[0])
+	}
+}
+
+func TestResolveAMultiValue(t *testing.T) {
+	a, store := newResolver(t, "auth-a")
+	store.Set(recordstore.Record{Name: "host.example.", Type: dns.TypeA, Values: []string{"1.2.3.4", "5.6.7.8", "not-an-ip"}, TTL: 30})
+
+	resp, err := a.Resolve(query("host.example", dns.TypeA), 4)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	// The two valid IPs are served; the malformed value is skipped.
+	if len(resp.Answer) != 2 {
+		t.Fatalf("expected 2 A answers (malformed skipped), got %d", len(resp.Answer))
+	}
+	if a0, ok := resp.Answer[0].(*dns.A); !ok || a0.Hdr.Ttl != 30 {
+		t.Fatalf("unexpected A answer: %+v", resp.Answer[0])
+	}
+}
+
+func TestResolveNXDOMAIN(t *testing.T) {
+	a, _ := newResolver(t, "auth-nx")
+	resp, err := a.Resolve(query("absent.example", dns.TypeA), 4)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if resp.Rcode != dns.RcodeNameError {
+		t.Fatalf("expected NXDOMAIN, got rcode=%d", resp.Rcode)
+	}
+	if len(resp.Answer) != 0 {
+		t.Fatalf("NXDOMAIN must have no answers")
+	}
+	if len(resp.Ns) != 1 {
+		t.Fatalf("expected a SOA in the authority section, got %d records", len(resp.Ns))
+	}
+	soa, ok := resp.Ns[0].(*dns.SOA)
+	if !ok || soa.Minttl != 60 {
+		t.Fatalf("unexpected SOA: %+v", resp.Ns[0])
+	}
+}
+
+func TestResolveNODATA(t *testing.T) {
+	a, store := newResolver(t, "auth-nodata")
+	store.Set(recordstore.Record{Name: "host.example.", Type: dns.TypeA, Values: []string{"1.2.3.4"}, TTL: 60})
+
+	// Name exists (A) but AAAA is queried -> NODATA: NOERROR, no answer, SOA present.
+	resp, err := a.Resolve(query("host.example", dns.TypeAAAA), 4)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("NODATA must be NOERROR, got rcode=%d", resp.Rcode)
+	}
+	if len(resp.Answer) != 0 || len(resp.Ns) != 1 {
+		t.Fatalf("NODATA must have no answer and a SOA, got answer=%d ns=%d", len(resp.Answer), len(resp.Ns))
+	}
+}
+
+func TestResolveCNAMEForOtherType(t *testing.T) {
+	a, store := newResolver(t, "auth-cname")
+	store.Set(recordstore.Record{Name: "alias.example.", Type: dns.TypeCNAME, Values: []string{"target.example.com"}, TTL: 60})
+
+	// An A query for a name that only has a CNAME returns the CNAME.
+	resp, err := a.Resolve(query("alias.example", dns.TypeA), 4)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected the CNAME to be returned, got %d answers", len(resp.Answer))
+	}
+	cname, ok := resp.Answer[0].(*dns.CNAME)
+	if !ok || cname.Target != "target.example.com." {
+		t.Fatalf("unexpected CNAME answer: %+v", resp.Answer[0])
+	}
+}
+
+func TestResolveDepthLimit(t *testing.T) {
+	a, _ := newResolver(t, "auth-depth")
+	if _, err := a.Resolve(query("x.example", dns.TypeA), -1); !errors.Is(err, resolverpkg.ErrLoopDetected) {
+		t.Fatalf("expected ErrLoopDetected at negative depth, got %v", err)
+	}
+}
+
+func TestDescriptorParsesConfig(t *testing.T) {
+	describable, ok := resolverpkg.GetResolverDescriptorByTypeName("authoritative")
+	if !ok {
+		t.Fatalf("authoritative resolver not registered")
+	}
+	obj, s, f := describable.Describe(map[string]interface{}{"store": "zone1", "negativeTTL": float64(120)})
+	if s < 1 || f > 0 {
+		t.Fatalf("describe failed: s=%d f=%d", s, f)
+	}
+	a := obj.(*Authoritative)
+	if a.Store != "zone1" || a.NegativeTTL != 120 {
+		t.Fatalf("unexpected parsed config: %+v", a)
+	}
+
+	// Empty config uses the defaults.
+	obj2, s2, f2 := describable.Describe(map[string]interface{}{})
+	if s2 < 1 || f2 > 0 {
+		t.Fatalf("describe of empty config failed: s=%d f=%d", s2, f2)
+	}
+	if d := obj2.(*Authoritative); d.Store != "" || d.NegativeTTL != 60 {
+		t.Fatalf("unexpected defaults: %+v", d)
+	}
+}


### PR DESCRIPTION
First half of the authoritative-zone feature (**issue #6**, v1.5.0 MVP): answer DNS from a process-local store instead of forwarding upstream — for serving dynamic records such as ACME DNS-01 `_acme-challenge` TXTs without running a second daemon. The **admin API** that populates the store lands in the next PR.

## `internal/recordstore`

An in-memory, TTL-aware, concurrency-safe set of records keyed by `{canonical name, type}`:
- per-record **store-expiry** (`ExpiresAt`), auto-reclaimed by a background sweep; reads skip expired entries regardless.
- stores are **shared by name** through a small registry, so a resolver and an admin listener that name the same store operate on one record set; an empty name joins `"default"`.

## `internal/upstream/resolvers/authoritative`

A `Resolver` that returns:
- the store's record for `{name, type}`;
- a **CNAME** at the name for any other type (requester re-queries the target);
- **NODATA** (NOERROR) when the name exists for another type;
- **NXDOMAIN** otherwise;

each negative answer carrying a **synthesized SOA** (reserved `.invalid.` placeholders, configurable MINTTL) for downstream negative caching. Config: `store` (shared store name) and `negativeTTL` (default 60). Answers are unsigned; DNSSEC signing, AXFR, and DDNS are out of scope per the issue.

## Compatibility & tests

Behaviour is unchanged unless an `authoritative` resolver is configured. Tests cover the store (set/get/replace/delete, case/dot-insensitivity, expiry, NODATA-vs-NXDOMAIN naming, shared-by-name registry) and the resolver (TXT/A hits, malformed-value skipping, NODATA, NXDOMAIN+SOA, CNAME-for-other-type, depth limit, descriptor parsing).

**Validation:** full `go build`/`go vet`/`go test ./...` green; `go test -race -count=2` on both new packages **clean on the validation host**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)