### PR TITLE
feat(admin): bearer-authenticated HTTP admin API for the record store

### DIFF
--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -96,6 +96,31 @@ func TestLoadConfigEcsDefaultsAreStrings(t *testing.T) {
 	}
 }
 
+func TestLoadConfigAuthoritativeAndAdmin(t *testing.T) {
+	// The authoritative resolver and the admin listener share a store by name; this
+	// asserts the whole config pipeline accepts both new types. The default resolver is
+	// declared inline (no named resolver) to avoid mutating the process-global resolver
+	// name registry this package's other tests rely on.
+	json := `{
+  "listeners": [
+    {"type": "dnsServer", "config": {"listen": "127.0.0.1", "port": 5353, "protocol": "udp"}},
+    {"type": "httpAdminServer", "config": {"listen": "127.0.0.1", "port": 9053, "token": "secret", "store": "acme"}}
+  ],
+  "rules": [],
+  "defaultResolver": {"type": "authoritative", "config": {"store": "acme", "negativeTTL": 30}}
+}`
+	instance, err := LoadConfig(strings.NewReader(json))
+	if err != nil {
+		t.Fatalf("LoadConfig returned error: %v", err)
+	}
+	if instance == nil {
+		t.Fatalf("expected an instance")
+	}
+	if _, ok := instance.GetResolver(); !ok {
+		t.Fatalf("expected default resolver to be configured")
+	}
+}
+
 func TestLoadConfigReportsKnownResolversOnNotFound(t *testing.T) {
 	json := `{
   "listeners": [

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/zhouchenh/secDNS/internal/config/typed/provider"
 
 	_ "github.com/zhouchenh/secDNS/internal/listeners/servers/dns/server"
+	_ "github.com/zhouchenh/secDNS/internal/listeners/servers/http/admin/server"
 	_ "github.com/zhouchenh/secDNS/internal/listeners/servers/http/api/server"
 
 	_ "github.com/zhouchenh/secDNS/internal/upstream/resolvers/address"

--- a/internal/listeners/servers/http/admin/server/errors.go
+++ b/internal/listeners/servers/http/admin/server/errors.go
@@ -1,0 +1,17 @@
+package server
+
+import "errors"
+
+var (
+	// ErrMissingToken makes the admin listener fail closed: it refuses to serve without a
+	// configured bearer token, so the mutating API can never run unauthenticated.
+	ErrMissingToken = errors.New("listeners/servers/http/admin/server: no bearer token configured; refusing to serve")
+
+	errMissingBearer = errors.New("missing or malformed Authorization: Bearer header")
+	errInvalidBearer = errors.New("invalid bearer token")
+	errBadType       = errors.New("unsupported record type (allowed: TXT, A, AAAA, CNAME)")
+	errBadName       = errors.New("name is not a valid DNS name")
+	errEmptyValues   = errors.New("values must be a non-empty array")
+	errBadIP         = errors.New("values must be valid IP addresses for an A/AAAA record")
+	errBadExpiry     = errors.New("expires_in_seconds must not be negative")
+)

--- a/internal/listeners/servers/http/admin/server/types.go
+++ b/internal/listeners/servers/http/admin/server/types.go
@@ -1,0 +1,345 @@
+// Package server implements the HTTP admin listener that populates the record store the
+// authoritative resolver answers from. It exposes a small bearer-authenticated CRUD API
+// (POST/DELETE/GET /admin/records) and is meant to bind a loopback or management address,
+// never the public internet. It fails closed: without a configured token it refuses to
+// serve.
+package server
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/zhouchenh/go-descriptor"
+	"github.com/zhouchenh/secDNS/internal/common"
+	"github.com/zhouchenh/secDNS/internal/recordstore"
+	"github.com/zhouchenh/secDNS/pkg/listeners/server"
+)
+
+// maxRequestBodyBytes bounds the request body; a record payload is tiny.
+const maxRequestBodyBytes = 64 << 10
+
+// allowedTypes is the record-type set the admin API accepts (issue #6 initial set).
+var allowedTypes = map[uint16]bool{
+	dns.TypeTXT:   true,
+	dns.TypeA:     true,
+	dns.TypeAAAA:  true,
+	dns.TypeCNAME: true,
+}
+
+type HTTPAdminServer struct {
+	Listen net.IP
+	Port   uint16
+	Path   string
+	Store  string // shared store name; empty joins recordstore.DefaultName
+	Token  string // bearer token; required (the listener fails closed without it)
+
+	store *recordstore.Store
+}
+
+var typeOfHTTPAdminServer = descriptor.TypeOfNew(new(*HTTPAdminServer))
+
+func (h *HTTPAdminServer) Type() descriptor.Type {
+	return typeOfHTTPAdminServer
+}
+
+func (h *HTTPAdminServer) TypeName() string {
+	return "httpAdminServer"
+}
+
+// Serve starts the admin HTTP API. The DNS resolve handler is irrelevant here (the admin
+// API does not resolve) and is ignored.
+func (h *HTTPAdminServer) Serve(_ func(query *dns.Msg) (reply *dns.Msg), errorHandler func(err error)) {
+	if strings.TrimSpace(h.Token) == "" {
+		handleIfError(ErrMissingToken, errorHandler)
+		return
+	}
+	h.store = recordstore.GetOrCreate(h.Store)
+	srv := &http.Server{
+		Addr:              net.JoinHostPort(h.Listen.String(), strconv.Itoa(int(h.Port))),
+		Handler:           h.routes(),
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       10 * time.Second,
+		WriteTimeout:      10 * time.Second,
+		IdleTimeout:       60 * time.Second,
+		MaxHeaderBytes:    8 << 10,
+	}
+	handleIfError(srv.ListenAndServe(), errorHandler)
+}
+
+// routes builds the authenticated request multiplexer. It is separated from Serve so
+// the handlers can be driven in tests without binding a socket.
+func (h *HTTPAdminServer) routes() *http.ServeMux {
+	base := h.basePath()
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET "+base+"/records", h.auth(h.handleList))
+	mux.HandleFunc("POST "+base+"/records", h.auth(h.handleSet))
+	mux.HandleFunc("DELETE "+base+"/records/{name}/{type}", h.auth(h.handleDelete))
+	return mux
+}
+
+func (h *HTTPAdminServer) basePath() string {
+	p := h.Path
+	if p == "" {
+		p = "/admin"
+	}
+	if !strings.HasPrefix(p, "/") {
+		p = "/" + p
+	}
+	return strings.TrimRight(p, "/")
+}
+
+// auth wraps a handler with the bearer-token check: a missing or malformed
+// Authorization header is 401, a present-but-wrong token is 403 (constant-time compared).
+func (h *HTTPAdminServer) auth(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		token, ok := bearerToken(r)
+		if !ok {
+			writeError(w, http.StatusUnauthorized, errMissingBearer)
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(token), []byte(h.Token)) != 1 {
+			writeError(w, http.StatusForbidden, errInvalidBearer)
+			return
+		}
+		next(w, r)
+	}
+}
+
+func bearerToken(r *http.Request) (string, bool) {
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if len(h) <= len(prefix) || !strings.EqualFold(h[:len(prefix)], prefix) {
+		return "", false
+	}
+	token := strings.TrimSpace(h[len(prefix):])
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+type setRequest struct {
+	Name             string   `json:"name"`
+	Type             string   `json:"type"`
+	Values           []string `json:"values"`
+	TTLSeconds       uint32   `json:"ttl_seconds"`
+	ExpiresInSeconds *int64   `json:"expires_in_seconds,omitempty"`
+}
+
+func (h *HTTPAdminServer) handleSet(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodyBytes)
+	var req setRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	rec, err := req.toRecord(time.Now())
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err)
+		return
+	}
+	h.store.Set(rec)
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (h *HTTPAdminServer) handleDelete(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	rrtype, ok := dns.StringToType[strings.ToUpper(r.PathValue("type"))]
+	if !ok || !allowedTypes[rrtype] {
+		writeError(w, http.StatusBadRequest, errBadType)
+		return
+	}
+	if !validName(name) {
+		writeError(w, http.StatusBadRequest, errBadName)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]bool{"deleted": h.store.Delete(name, rrtype)})
+}
+
+type recordJSON struct {
+	Name       string   `json:"name"`
+	Type       string   `json:"type"`
+	Values     []string `json:"values"`
+	TTLSeconds uint32   `json:"ttl_seconds"`
+	ExpiresAt  string   `json:"expires_at,omitempty"`
+}
+
+func (h *HTTPAdminServer) handleList(w http.ResponseWriter, _ *http.Request) {
+	recs := h.store.List()
+	out := make([]recordJSON, 0, len(recs))
+	for _, rec := range recs {
+		rj := recordJSON{
+			Name:       rec.Name,
+			Type:       dns.TypeToString[rec.Type],
+			Values:     rec.Values,
+			TTLSeconds: rec.TTL,
+		}
+		if !rec.ExpiresAt.IsZero() {
+			rj.ExpiresAt = rec.ExpiresAt.UTC().Format(time.RFC3339)
+		}
+		out = append(out, rj)
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{"records": out})
+}
+
+// toRecord validates the request and converts it to a store record relative to now.
+func (req setRequest) toRecord(now time.Time) (recordstore.Record, error) {
+	name := strings.TrimSpace(req.Name)
+	if !validName(name) {
+		return recordstore.Record{}, errBadName
+	}
+	rrtype, ok := dns.StringToType[strings.ToUpper(strings.TrimSpace(req.Type))]
+	if !ok || !allowedTypes[rrtype] {
+		return recordstore.Record{}, errBadType
+	}
+	if len(req.Values) == 0 {
+		return recordstore.Record{}, errEmptyValues
+	}
+	if rrtype == dns.TypeA || rrtype == dns.TypeAAAA {
+		for _, v := range req.Values {
+			ip := net.ParseIP(strings.TrimSpace(v))
+			if ip == nil || (rrtype == dns.TypeA) != (ip.To4() != nil) {
+				return recordstore.Record{}, errBadIP
+			}
+		}
+	}
+	ttl := req.TTLSeconds
+	if ttl == 0 {
+		ttl = 60
+	}
+	rec := recordstore.Record{Name: name, Type: rrtype, Values: req.Values, TTL: ttl}
+	if req.ExpiresInSeconds != nil {
+		if *req.ExpiresInSeconds < 0 {
+			return recordstore.Record{}, errBadExpiry
+		}
+		if *req.ExpiresInSeconds > 0 {
+			rec.ExpiresAt = now.Add(time.Duration(*req.ExpiresInSeconds) * time.Second)
+		}
+	}
+	return rec, nil
+}
+
+func validName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" || len(name) > 255 {
+		return false
+	}
+	_, ok := dns.IsDomainName(name)
+	return ok
+}
+
+func writeJSON(w http.ResponseWriter, status int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, err error) {
+	writeJSON(w, status, map[string]string{"error": err.Error()})
+}
+
+func handleIfError(err error, errorHandler func(err error)) {
+	if err != nil && errorHandler != nil {
+		errorHandler(err)
+	}
+}
+
+func init() {
+	if err := server.RegisterServer(&descriptor.Descriptor{
+		Type: typeOfHTTPAdminServer,
+		Filler: descriptor.Fillers{
+			descriptor.ObjectFiller{
+				ObjectPath: descriptor.Path{"Listen"},
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath: descriptor.Path{"listen"},
+						AssignableKind: descriptor.ConvertibleKind{
+							Kind: descriptor.KindString,
+							ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+								str, ok := original.(string)
+								if !ok {
+									return
+								}
+								converted = net.ParseIP(str)
+								ok = converted != nil
+								return
+							},
+						},
+					},
+					// Loopback by default: the admin API must not be reachable off-host
+					// unless the operator deliberately binds a routable address.
+					descriptor.DefaultValue{Value: net.ParseIP("127.0.0.1")},
+				},
+			},
+			descriptor.ObjectFiller{
+				ObjectPath: descriptor.Path{"Port"},
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath: descriptor.Path{"port"},
+						AssignableKind: descriptor.AssignableKinds{
+							descriptor.ConvertibleKind{
+								Kind: descriptor.KindFloat64,
+								ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+									i := int(original.(float64))
+									if i < 0 || i > 65535 {
+										return nil, false
+									}
+									return uint16(i), true
+								},
+							},
+							descriptor.ConvertibleKind{
+								Kind: descriptor.KindString,
+								ConvertFunction: func(original interface{}) (converted interface{}, ok bool) {
+									i, err := strconv.Atoi(strings.TrimSpace(original.(string)))
+									if err != nil || i < 0 || i > 65535 {
+										return nil, false
+									}
+									return uint16(i), true
+								},
+							},
+						},
+					},
+					descriptor.DefaultValue{Value: uint16(9053)},
+				},
+			},
+			descriptor.ObjectFiller{
+				ObjectPath: descriptor.Path{"Path"},
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath:     descriptor.Path{"path"},
+						AssignableKind: descriptor.KindString,
+					},
+					descriptor.DefaultValue{Value: "/admin"},
+				},
+			},
+			descriptor.ObjectFiller{
+				ObjectPath: descriptor.Path{"Store"},
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath:     descriptor.Path{"store"},
+						AssignableKind: descriptor.KindString,
+					},
+					descriptor.DefaultValue{Value: ""},
+				},
+			},
+			descriptor.ObjectFiller{
+				ObjectPath: descriptor.Path{"Token"},
+				ValueSource: descriptor.ValueSources{
+					descriptor.ObjectAtPath{
+						ObjectPath:     descriptor.Path{"token"},
+						AssignableKind: descriptor.KindString,
+					},
+					descriptor.DefaultValue{Value: ""},
+				},
+			},
+		},
+	}); err != nil {
+		common.ErrOutput(err)
+	}
+}

--- a/internal/listeners/servers/http/admin/server/types_test.go
+++ b/internal/listeners/servers/http/admin/server/types_test.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/zhouchenh/secDNS/internal/recordstore"
+	"github.com/zhouchenh/secDNS/internal/upstream/resolvers/authoritative"
+)
+
+const testToken = "s3cr3t-token"
+
+func newServer(t *testing.T, storeName string) *HTTPAdminServer {
+	t.Helper()
+	h := &HTTPAdminServer{Token: testToken, Store: storeName}
+	h.store = recordstore.GetOrCreate(storeName)
+	return h
+}
+
+func do(h *HTTPAdminServer, method, target, token, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(method, target, strings.NewReader(body))
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	rec := httptest.NewRecorder()
+	h.routes().ServeHTTP(rec, req)
+	return rec
+}
+
+func TestServeFailsClosedWithoutToken(t *testing.T) {
+	h := &HTTPAdminServer{Token: "  "} // blank token
+	var got error
+	h.Serve(nil, func(err error) { got = err })
+	if !errors.Is(got, ErrMissingToken) {
+		t.Fatalf("a tokenless admin listener must refuse to serve, got %v", got)
+	}
+}
+
+func TestAuth(t *testing.T) {
+	h := newServer(t, "admin-auth")
+
+	if rec := do(h, http.MethodGet, "/admin/records", "", ""); rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no bearer -> want 401, got %d", rec.Code)
+	}
+	if rec := do(h, http.MethodGet, "/admin/records", "wrong", ""); rec.Code != http.StatusForbidden {
+		t.Fatalf("wrong bearer -> want 403, got %d", rec.Code)
+	}
+	if rec := do(h, http.MethodGet, "/admin/records", testToken, ""); rec.Code != http.StatusOK {
+		t.Fatalf("correct bearer -> want 200, got %d", rec.Code)
+	}
+}
+
+func TestSetGetDeleteRoundTrip(t *testing.T) {
+	h := newServer(t, "admin-rt")
+
+	// POST a TXT record (the ACME shape).
+	body := `{"name":"_acme-challenge.example.com","type":"TXT","values":["tok"],"ttl_seconds":60}`
+	if rec := do(h, http.MethodPost, "/admin/records", testToken, body); rec.Code != http.StatusOK {
+		t.Fatalf("POST -> want 200, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if got, ok := h.store.Get("_acme-challenge.example.com", dns.TypeTXT); !ok || got.Values[0] != "tok" {
+		t.Fatalf("record not stored: %+v ok=%v", got, ok)
+	}
+
+	// GET list shows it.
+	rec := do(h, http.MethodGet, "/admin/records", testToken, "")
+	var listed struct {
+		Records []recordJSON `json:"records"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listed.Records) != 1 || listed.Records[0].Type != "TXT" {
+		t.Fatalf("unexpected list: %+v", listed.Records)
+	}
+
+	// DELETE it.
+	rec = do(h, http.MethodDelete, "/admin/records/_acme-challenge.example.com/TXT", testToken, "")
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"deleted":true`) {
+		t.Fatalf("DELETE -> want 200 deleted:true, got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if _, ok := h.store.Get("_acme-challenge.example.com", dns.TypeTXT); ok {
+		t.Fatalf("record still present after delete")
+	}
+	// Deleting again reports false.
+	rec = do(h, http.MethodDelete, "/admin/records/_acme-challenge.example.com/TXT", testToken, "")
+	if !strings.Contains(rec.Body.String(), `"deleted":false`) {
+		t.Fatalf("second DELETE should report deleted:false, got %s", rec.Body.String())
+	}
+}
+
+func TestSetValidation(t *testing.T) {
+	h := newServer(t, "admin-validate")
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"bad type", `{"name":"x.example.","type":"MX","values":["1 mail."]}`},
+		{"bad A ip", `{"name":"x.example.","type":"A","values":["not-an-ip"]}`},
+		{"AAAA given v4", `{"name":"x.example.","type":"AAAA","values":["1.2.3.4"]}`},
+		{"empty values", `{"name":"x.example.","type":"TXT","values":[]}`},
+		{"bad name", `{"name":"a..b.example.","type":"TXT","values":["v"]}`}, // empty interior label
+		{"negative expiry", `{"name":"x.example.","type":"TXT","values":["v"],"expires_in_seconds":-5}`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if rec := do(h, http.MethodPost, "/admin/records", testToken, c.body); rec.Code != http.StatusBadRequest {
+				t.Fatalf("want 400, got %d (%s)", rec.Code, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestSetExpiryComputed(t *testing.T) {
+	now := time.Unix(2_000_000_000, 0)
+	req := setRequest{Name: "x.example.", Type: "TXT", Values: []string{"v"}, ExpiresInSeconds: ptr(int64(1800))}
+	rec, err := req.toRecord(now)
+	if err != nil {
+		t.Fatalf("toRecord: %v", err)
+	}
+	if want := now.Add(1800 * time.Second); !rec.ExpiresAt.Equal(want) {
+		t.Fatalf("ExpiresAt = %v, want %v", rec.ExpiresAt, want)
+	}
+	if rec.TTL != 60 {
+		t.Fatalf("ttl should default to 60, got %d", rec.TTL)
+	}
+
+	// No expires_in_seconds -> no expiry.
+	req2 := setRequest{Name: "y.example.", Type: "TXT", Values: []string{"v"}}
+	rec2, _ := req2.toRecord(now)
+	if !rec2.ExpiresAt.IsZero() {
+		t.Fatalf("omitted expiry must leave ExpiresAt zero, got %v", rec2.ExpiresAt)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+
+// TestAdminToResolverIntegration is the cross-component proof: a record POSTed through
+// the admin API is answered by an authoritative resolver that names the same store —
+// the full ACME DNS-01 shape (the LE validator's TXT query resolves to the token).
+func TestAdminToResolverIntegration(t *testing.T) {
+	const storeName = "admin-integration"
+	h := newServer(t, storeName)
+
+	body := `{"name":"_acme-challenge.example.com","type":"TXT","values":["challenge-token"],"ttl_seconds":60,"expires_in_seconds":1800}`
+	if rec := do(h, http.MethodPost, "/admin/records", testToken, body); rec.Code != http.StatusOK {
+		t.Fatalf("POST failed: %d (%s)", rec.Code, rec.Body.String())
+	}
+
+	a := &authoritative.Authoritative{Store: storeName}
+	q := new(dns.Msg)
+	q.SetQuestion("_acme-challenge.example.com.", dns.TypeTXT)
+	resp, err := a.Resolve(q, 4)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("want 1 answer from the shared store, got %d", len(resp.Answer))
+	}
+	if txt, ok := resp.Answer[0].(*dns.TXT); !ok || txt.Txt[0] != "challenge-token" {
+		t.Fatalf("unexpected answer: %+v", resp.Answer[0])
+	}
+
+	// After deletion through the API, the resolver returns NXDOMAIN.
+	if rec := do(h, http.MethodDelete, "/admin/records/_acme-challenge.example.com/TXT", testToken, ""); rec.Code != http.StatusOK {
+		t.Fatalf("DELETE failed: %d", rec.Code)
+	}
+	resp2, _ := a.Resolve(q, 4)
+	if resp2.Rcode != dns.RcodeNameError {
+		t.Fatalf("after delete want NXDOMAIN, got rcode=%d", resp2.Rcode)
+	}
+}


### PR DESCRIPTION
Second half of the authoritative-zone feature (**issue #6**, v1.5.0 MVP): a dedicated HTTP listener that populates the store the authoritative resolver (#52) answers from. Meant to bind a loopback or management address, it **fails closed** — without a configured bearer token it refuses to serve, so the mutating API can never run open.

## New listener: `httpAdminServer`

Config: `listen` (default `127.0.0.1`), `port` (default `9053`), `path` (default `/admin`), `store` (shared store name), `token` (**required**). Endpoints, each bearer-authenticated:

| Method | Path | Body / effect |
|--------|------|---------------|
| `POST` | `{path}/records` | set/replace `{name, type, values, ttl_seconds, expires_in_seconds?}`; type ∈ TXT/A/AAAA/CNAME; names + IPs validated; idempotent |
| `DELETE` | `{path}/records/{name}/{type}` | remove; reports whether one was present |
| `GET` | `{path}/records` | list the live records |

Auth is a static bearer token compared in **constant time**: missing/malformed `Authorization` → **401**, wrong token → **403**. The resolver and listener join the same store by name, so a record POSTed here is immediately answered by the authoritative resolver.

## Tests

Fail-closed without a token; 401/403/200 auth; set/get/list/delete round trip; request validation (bad type, bad/family-mismatched IP, empty values, malformed name, negative expiry); computed expiry; a **cross-component integration test** (admin `POST` → authoritative TXT answer → admin `DELETE` → NXDOMAIN); and a full `LoadConfig` pipeline test with both new types sharing a store.

## Validation

`go build`/`go vet`/`go test ./...` green; **`go test -race ./...` clean on the validation host** (30 packages ok, no races).

> Note: while testing I found a *pre-existing* test-isolation quirk in `internal/config` (the named-resolver registry accumulates across `LoadConfig` calls, surfacing only under `-count=2`). It's independent of this change and benign in production (one config load per process); flagging for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)