### PR TITLE
release: v1.5.0

### DIFF
--- a/docs/listeners.md
+++ b/docs/listeners.md
@@ -4,3 +4,4 @@ secDNS supports the following listeners. Use the version annotations to ensure y
 
 * [dnsServer](listeners/dns_server.md) - Plain DNS (UDP/TCP) listener that terminates queries on a socket. It does **not** speak DoT/DoH.
 * [httpAPIServer](listeners/http_api_server.md) - (secDNS v1.2.1+) HTTP/JSON endpoint that accepts GET or POST (form or JSON) requests and returns DNS responses encoded as JSON.
+* [httpAdminServer](listeners/http_admin_server.md) - (secDNS v1.5.0+) Bearer-authenticated HTTP admin API (loopback by default) that populates the record store the `authoritative` resolver answers from.

--- a/docs/listeners/http_admin_server.md
+++ b/docs/listeners/http_admin_server.md
@@ -1,0 +1,127 @@
+# httpAdminServer
+
+_Available in secDNS v1.5.0 and later._
+
+* Type: `httpAdminServer`
+
+The `httpAdminServer` listener exposes a small bearer-authenticated HTTP API that
+populates the record store the [`authoritative`](../resolvers/authoritative.md) resolver
+answers from. It is intended to bind a **loopback or management address** and must never be
+exposed to the public internet.
+
+It **fails closed**: without a configured `token` it refuses to serve, so the mutating API
+can never run unauthenticated. The listener and the authoritative resolver join the same
+store by `store` name, so a record written here is immediately answered by the resolver.
+
+## ListenerConfigObject
+
+```json
+{
+  "listen": "127.0.0.1",
+  "port": 9053,
+  "path": "/admin",
+  "store": "acme",
+  "token": "a-long-random-secret"
+}
+```
+
+> `listen`: String _(Optional)_
+
+The IP address to bind. Defaults to loopback; set a routable address only deliberately,
+behind appropriate network controls.
+
+Default: `127.0.0.1`
+
+> `port`: Number | String _(Optional)_
+
+The port to listen on (number or numeric string).
+
+Default: `9053`
+
+> `path`: String _(Optional)_
+
+Base path for the admin endpoints. A leading slash is added if omitted; a trailing slash is
+trimmed.
+
+Default: `/admin`
+
+> `store`: String _(Optional)_
+
+Name of the shared record store to mutate. Must match the `authoritative` resolver's
+`store`. An empty value joins the `default` store.
+
+Default: `""` (the `default` store)
+
+> `token`: String _(Required)_
+
+Bearer token required on every request. The listener refuses to serve if this is empty.
+Use a long, random value and transport it over loopback or TLS-terminating infrastructure.
+
+## Authentication
+
+Every endpoint requires `Authorization: Bearer <token>`. The token is compared in constant
+time. A missing or malformed header returns **401**; a present but incorrect token returns
+**403**.
+
+## Endpoints
+
+> `POST {path}/records`
+
+Set or replace the record for a `{name, type}` (idempotent).
+
+```json
+{
+  "name": "_acme-challenge.example.com",
+  "type": "TXT",
+  "values": ["challenge-token"],
+  "ttl_seconds": 60,
+  "expires_in_seconds": 1800
+}
+```
+
+* `type`: one of `TXT`, `A`, `AAAA`, `CNAME`.
+* `values`: non-empty array. For `A`/`AAAA` each value must be a valid address of the
+  matching family; for `CNAME` the first value is the target; for `TXT` each value is a
+  character-string.
+* `ttl_seconds`: DNS TTL served in answers (defaults to `60` when omitted/zero).
+* `expires_in_seconds` _(optional)_: store lifetime — the record is auto-removed after this
+  many seconds. Omit (or `0`) for no expiry. Must not be negative.
+
+Returns `{"status": "ok"}`.
+
+> `DELETE {path}/records/{name}/{type}`
+
+Remove the record for `{name, type}`. Returns `{"deleted": true|false}` indicating whether
+one was present.
+
+> `GET {path}/records`
+
+List the live (non-expired) records:
+
+```json
+{
+  "records": [
+    {"name": "_acme-challenge.example.com.", "type": "TXT", "values": ["challenge-token"], "ttl_seconds": 60, "expires_at": "2026-06-05T05:30:00Z"}
+  ]
+}
+```
+
+## Errors
+
+Validation and auth failures return an HTTP status and a JSON body:
+
+```json
+{"error": "unsupported record type (allowed: TXT, A, AAAA, CNAME)"}
+```
+
+## ACME DNS-01 walkthrough
+
+1. Publish, in your real zone, a delegation for the challenge subzone to the host running
+   secDNS, and a `CNAME` from `_acme-challenge.example.com` to a name under that subzone.
+2. Route `*.acme-validation.example.com` (the subzone) to an `authoritative` resolver via a
+   rule, sharing a store with this listener.
+3. The ACME client requests a certificate; the CA returns a token `T`.
+4. The client `POST`s the token: `{name: "_acme-challenge.acme-validation.example.com",
+   type: "TXT", values: [T], ttl_seconds: 60, expires_in_seconds: 1800}`.
+5. The CA resolves the challenge name, follows the `CNAME` to secDNS, and reads the `TXT`.
+6. On success the client `DELETE`s the record.

--- a/docs/resolvers.md
+++ b/docs/resolvers.md
@@ -4,6 +4,7 @@ secDNS supports the following resolvers.
 
 * [address](resolvers/address.md) - Reply with fixed IPv4/IPv6 addresses.
 * [alias](resolvers/alias.md) - Reply with a CNAME (and optionally chase the target).
+* [authoritative](resolvers/authoritative.md) - (secDNS v1.5.0+) Answer from a process-local record store (NXDOMAIN/NODATA with a synthesized SOA otherwise), populated by the admin API.
 * [cache](resolvers/cache.md) - (secDNS v1.2.0+) Cache upstream responses with LRU eviction, TTL management, negative caching, prefetch, and stale serving.
 * [concurrentNameServerList](resolvers/concurrent_name_server_list.md) - Forward queries to multiple resolvers concurrently and return the first answer.
 * [dns64](resolvers/dns64.md) - (secDNS v1.1.0+) Synthesize AAAA records from A responses.

--- a/docs/resolvers/authoritative.md
+++ b/docs/resolvers/authoritative.md
@@ -1,0 +1,53 @@
+# authoritative
+
+_Available in secDNS v1.5.0 and later._
+
+* Type: `authoritative`
+
+The `authoritative` resolver answers from a process-local record store instead of
+forwarding upstream. Names routed to it (via [rules](../rules.md)) are answered from the
+store; unknown names return `NXDOMAIN`, a known name queried for a type it does not have
+returns `NODATA` (NOERROR with an empty answer), and each negative answer carries a
+synthesized `SOA` in the authority section for negative caching.
+
+The store is populated out of band — typically by the [`httpAdminServer`](../listeners/http_admin_server.md)
+admin API — and is **shared by name**, so an `authoritative` resolver and an admin
+listener configured with the same `store` operate on one record set. This is the building
+block for serving dynamic records such as ACME DNS-01 `_acme-challenge` TXT records without
+running a second daemon.
+
+Supported record types: `TXT`, `A`, `AAAA`, `CNAME`. A `CNAME` stored for a name is
+returned for a query of any other type (the requester re-queries the target). Answers are
+unsigned; DNSSEC signing, zone transfer (AXFR/IXFR), and dynamic DNS updates (RFC 2136) are
+out of scope.
+
+## ResolverConfigObject
+
+```json
+{
+  "store": "acme",
+  "negativeTTL": 60
+}
+```
+
+> `store`: String _(Optional)_
+
+Name of the shared record store to answer from. An empty value joins the `default` store.
+Use the same value on the `httpAdminServer` listener that populates it.
+
+Default: `""` (the `default` store)
+
+> `negativeTTL`: Number | String _(Optional)_
+
+TTL (seconds) of the synthesized `SOA` and its `MINIMUM` field, which bounds how long
+downstream resolvers negatively cache an `NXDOMAIN`/`NODATA` answer. Accepts a number or a
+numeric string.
+
+Default: `60`
+
+## Notes
+
+* The resolver does not track a zone apex: the synthesized `SOA` is owned by the queried
+  name and uses placeholder `MNAME`/`RNAME` under the reserved `.invalid.` TLD (RFC 6761).
+  Only the `MINIMUM`/TTL is operationally meaningful (negative-cache duration).
+* With no admin listener and no records, every routed name returns `NXDOMAIN`.

--- a/docs/version_history.md
+++ b/docs/version_history.md
@@ -1,5 +1,33 @@
 # Version History
 
+## v1.5.0 - 2026.06.05
+
+Authoritative Resolver and Admin API
+
+This release adds the ability to answer DNS authoritatively from a process-local record
+store, populated dynamically over a bearer-authenticated HTTP admin API — for serving
+records such as ACME DNS-01 `_acme-challenge` TXTs without running a second daemon.
+Configuration is backward-compatible: the new behavior is inactive unless an
+`authoritative` resolver or `httpAdminServer` listener is configured.
+
+* resolvers: add an `authoritative` resolver. It answers from a shared, in-memory,
+  TTL-aware record store instead of forwarding upstream — returning the store's record for
+  a name, a stored `CNAME` for a query of any other type, `NODATA` (NOERROR) when the name
+  exists for another type, and `NXDOMAIN` otherwise, each negative answer carrying a
+  synthesized `SOA` (configurable `negativeTTL`) for downstream negative caching. Supported
+  types are `TXT`, `A`, `AAAA`, and `CNAME`; answers are unsigned. Stores are shared by
+  name (`store`, default `default`), so a resolver and an admin listener that name the same
+  store operate on one record set.
+* listeners: add an `httpAdminServer` listener — a bearer-authenticated HTTP admin API
+  (`POST`/`DELETE`/`GET {path}/records`) that populates the record store the `authoritative`
+  resolver answers from. It binds loopback by default and fails closed, refusing to serve
+  without a configured `token`; the token is compared in constant time, a missing or
+  malformed `Authorization` header is `401` and a wrong token `403`. Record writes accept a
+  DNS TTL (`ttl_seconds`) and an optional store lifetime (`expires_in_seconds`) after which
+  the record is auto-removed. Names, record types, and IP values are validated.
+* docs: add `docs/resolvers/authoritative.md`, `docs/listeners/http_admin_server.md`, and
+  an end-to-end ACME DNS-01 example (`examples/acme-dns01-config.json`).
+
 ## v1.4.6 - 2026.06.05
 
 Concurrent Glue Resolution

--- a/examples/acme-dns01-config.json
+++ b/examples/acme-dns01-config.json
@@ -1,0 +1,32 @@
+{
+  "listeners": [
+    { "type": "dnsServer", "config": { "listen": "0.0.0.0", "port": 53, "protocol": "udp" } },
+    { "type": "dnsServer", "config": { "listen": "0.0.0.0", "port": 53, "protocol": "tcp" } },
+    {
+      "type": "httpAdminServer",
+      "config": {
+        "listen": "127.0.0.1",
+        "port": 9053,
+        "store": "acme",
+        "token": "replace-with-a-long-random-secret"
+      }
+    }
+  ],
+  "resolvers": {
+    "authoritative": {
+      "acmeAuth": { "store": "acme", "negativeTTL": 30 }
+    },
+    "recursive": {
+      "rec": {}
+    }
+  },
+  "rules": [
+    {
+      "type": "collection",
+      "config": [
+        { "name": "acme-validation.example.com", "resolver": "acmeAuth" }
+      ]
+    }
+  ],
+  "defaultResolver": "rec"
+}

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	name    = "secDNS"
-	version = "1.4.6"
+	version = "1.5.0"
 	build   = ""
 	intro   = "A DNS Resolver with custom rules."
 )


### PR DESCRIPTION
Bump version to **1.5.0** (minor — new feature) and add docs + changelog.

Changes since v1.4.6 (the authoritative-zone feature, **issue #6** MVP):

| PR | Change |
|----|--------|
| #52 | `authoritative` resolver + `recordstore` — answer DNS from a process-local, TTL-aware store (NXDOMAIN/NODATA + synthesized SOA otherwise) |
| #53 | `httpAdminServer` listener — bearer-authenticated admin API (loopback default, fails closed) that populates the shared store |

Plus per-type docs (`docs/resolvers/authoritative.md`, `docs/listeners/http_admin_server.md`), both index pages, and an end-to-end ACME DNS-01 example (`examples/acme-dns01-config.json`, validated with `-test`).

Configuration is backward-compatible — the new behavior is inactive unless an `authoritative` resolver or `httpAdminServer` listener is configured.

**Validation:** `go build`/`go vet`/`go test ./...` green; `go test -race ./...` clean on the validation host across the feature PRs; the example config passes `-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)