### PR TITLE
fix(config): clear pending named resolvers between config loads

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -20,6 +20,10 @@ func LoadConfig(r io.Reader) (core.Instance, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Start from a clean slate: describing the config below appends every string-referenced
+	// resolver to a process-global pending list, and a previous LoadConfig that failed
+	// before resolving that list would otherwise leave stale names behind.
+	named.ResetKnownNamedResolvers()
 	rawConfig, s, f := Descriptor().Describe(data)
 	ok := s > 0 && f < 1
 	if !ok {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -121,6 +121,32 @@ func TestLoadConfigAuthoritativeAndAdmin(t *testing.T) {
 	}
 }
 
+func TestLoadConfigDoesNotLeakFailedNamedResolvers(t *testing.T) {
+	// A first load fails because its default resolver names one that does not exist.
+	failing := `{
+  "listeners": [{"type": "dnsServer", "config": {"listen": "127.0.0.1", "port": 5353, "protocol": "udp"}}],
+  "resolvers": {"noAnswer": {"present": {}}},
+  "rules": [],
+  "defaultResolver": "missing-resolver"
+}`
+	if _, err := LoadConfig(strings.NewReader(failing)); err == nil {
+		t.Fatalf("expected the first load to fail on the missing resolver")
+	}
+
+	// A second, independent load that references a resolver it DOES declare must succeed:
+	// the failed load must not have left "missing-resolver" in the process-global pending
+	// list to be re-processed (and re-failed on) here.
+	valid := `{
+  "listeners": [{"type": "dnsServer", "config": {"listen": "127.0.0.1", "port": 5353, "protocol": "udp"}}],
+  "resolvers": {"noAnswer": {"only": {}}},
+  "rules": [],
+  "defaultResolver": "only"
+}`
+	if _, err := LoadConfig(strings.NewReader(valid)); err != nil {
+		t.Fatalf("second load inherited the first load's failure: %v", err)
+	}
+}
+
 func TestLoadConfigReportsKnownResolversOnNotFound(t *testing.T) {
 	json := `{
   "listeners": [

--- a/internal/config/named/resolver/types.go
+++ b/internal/config/named/resolver/types.go
@@ -118,7 +118,18 @@ func reportNamedResolver(namedResolver *NamedResolver) {
 	knownNamedResolvers = append(knownNamedResolvers, namedResolver)
 }
 
+// ResetKnownNamedResolvers clears the pending list of string-referenced resolvers. A
+// LoadConfig calls it before describing so a previous load — including one that failed
+// before InitKnownNamedResolvers ran — cannot leave stale entries that poison this one.
+func ResetKnownNamedResolvers() {
+	knownNamedResolvers = nil
+}
+
 func InitKnownNamedResolvers() error {
+	// Clear the list on every exit, not only on success: a not-found reference used to
+	// return early and leave its NamedResolver behind, so the next LoadConfig re-processed
+	// (and re-failed on) a name from the previous config.
+	defer ResetKnownNamedResolvers()
 	for _, namedResolver := range knownNamedResolvers {
 		if namedResolver.resolver != nil {
 			continue
@@ -128,6 +139,5 @@ func InitKnownNamedResolvers() error {
 			return NotFoundError(namedResolver.Name)
 		}
 	}
-	knownNamedResolvers = nil
 	return nil
 }


### PR DESCRIPTION
## Problem

A string resolver reference (`defaultResolver`/rule `"name"`) is appended to a **process-global** pending list while a config is described, and `InitKnownNamedResolvers` resolves that list at the end of `LoadConfig`. It cleared the list **only on success** — a not-found reference returned early (line 128) and left its entry behind. A later `LoadConfig` then re-processed, and re-failed on, a name from the earlier failed config.

Loading two configs in one process was therefore order-dependent. It surfaced in the test suite under `-count=2`, where the failed-load test (`…ReportsKnownResolvers…`) poisoned a later valid-load test (`…EcsDefaults…`), which then failed with `missing-resolver not found`.

(Found while adding the v1.5.0 admin-listener config test; flagged there as pre-existing.)

## Fix

- Reset the pending list on **every** exit of `InitKnownNamedResolvers` (`defer`, not only the success path).
- Additionally clear it at the **start of each `LoadConfig`**, so a load that fails *before* the resolve step (e.g. missing listeners) cannot leak either.

secDNS loads one config per process in normal operation, so this changes **no production behavior**; it makes repeated loads correct and the tests order-independent.

## Tests

`TestLoadConfigDoesNotLeakFailedNamedResolvers` — a load that fails on a missing named resolver must not cause the next, independent, valid load to fail. **Verified to fail without the fix** (`second load inherited the first load's failure: … missing-resolver not found (registered resolvers: [only])`) and pass with it.

**Validation:** `go build`/`go vet`/`go test ./...` green; `go test -race -count=3 ./internal/config/` and full `go test -race ./...` clean on the validation host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)