### PR TITLE
release: v1.5.1

### DIFF
--- a/docs/version_history.md
+++ b/docs/version_history.md
@@ -1,5 +1,22 @@
 # Version History
 
+## v1.5.1 - 2026.06.05
+
+Config-Load Isolation Fix
+
+This release fixes a latent bug in configuration loading. Configuration is
+backward-compatible.
+
+* config: clear the pending named-resolver list between loads. A string resolver
+  reference (a `defaultResolver` or rule `"name"`) is appended to a process-global pending
+  list while a config is described, and resolved at the end of the load. That list was
+  cleared only when the load succeeded; a not-found reference returned early and left its
+  entry behind, so a subsequent load in the same process re-processed — and re-failed on —
+  a name from the earlier failed config. The list is now cleared on every exit of the
+  resolve step and at the start of each load. secDNS loads one config per process in normal
+  operation, so this changes no runtime behavior; it makes repeated loads correct (and the
+  test suite order-independent).
+
 ## v1.5.0 - 2026.06.05
 
 Authoritative Resolver and Admin API

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	name    = "secDNS"
-	version = "1.5.0"
+	version = "1.5.1"
 	build   = ""
 	intro   = "A DNS Resolver with custom rules."
 )


### PR DESCRIPTION
Bump version to **1.5.1** (patch) and add the version-history entry.

Change since v1.5.0:

| PR | Change |
|----|--------|
| #55 | config: clear the pending named-resolver list between loads — a failed load no longer poisons a subsequent one in the same process |

Backward-compatible; no runtime behavior change (secDNS loads one config per process).

**Validation:** `go build`/`go vet`/`go test ./...` green; `go test -race -count=3 ./internal/config/` and full `go test -race ./...` clean on the validation host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)