### PR TITLE
Fix recursive resolver vet compatibility

### DIFF
--- a/internal/upstream/resolvers/recursive/types.go
+++ b/internal/upstream/resolvers/recursive/types.go
@@ -425,7 +425,7 @@ func (r *Recursive) initialize() {
 	validator.resolveDNSKEY = r.fetchDNSKEY
 	validator.resolveDS = r.fetchDS
 	validator.logger = func(msg string) {
-		common.ErrOutput(fmt.Errorf(msg))
+		common.ErrOutput(errors.New(msg))
 	}
 	if r.Nsec3MaxIterations > 0 {
 		validator.nsec3MaxIter = uint16(r.Nsec3MaxIterations)


### PR DESCRIPTION
## Summary\n- Replace the non-constant mt.Errorf(msg) logger call with errors.New(msg).\n- Keep resolver behavior unchanged while allowing Go 1.25+ module validation and vet to pass.\n\n## Verification\n- go test ./...\n- go vet ./...\n- git diff --check\n\nThis is a source-only fix. No live services, hosts, routers, DNS, ACME, databases, or secrets were accessed.